### PR TITLE
fix(addon): Add proper SAPISIDHASH auth headers to API test call (v1.…

### DIFF
--- a/familylink-playwright/config.json
+++ b/familylink-playwright/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Google Family Link Auth",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "slug": "familylink-playwright",
   "description": "Authentication service for Google Family Link integration using browser automation",
   "url": "https://github.com/noiwid/HAFamilyLink",


### PR DESCRIPTION
…2.2)

The fetch() API call in the browser context was missing the required authentication headers, causing it to always return 401. This fix:

- Generates SAPISIDHASH in JavaScript using Web Crypto API
- Includes Authorization header with SAPISIDHASH
- Adds X-Goog-AuthUser and x-goog-api-key headers
- Sets correct Origin header

This should properly validate authentication and ensure cookies are configured correctly for the kidsmanagement API.

Version: 1.2.2