### PR TITLE
Fix: Pass child_id to device control API for multiple children support

### DIFF
--- a/custom_components/familylink/client/api.py
+++ b/custom_components/familylink/client/api.py
@@ -648,7 +648,7 @@ class FamilyLinkClient:
 			"failed_apps": failed,
 		}
 
-	async def async_control_device(self, device_id: str, action: str) -> bool:
+	async def async_control_device(self, device_id: str, action: str, child_id: str | None = None) -> bool:
 		"""Control a Family Link device (lock/unlock).
 
 		Uses the timeLimitOverrides:batchCreate endpoint discovered from browser DevTools.
@@ -656,6 +656,7 @@ class FamilyLinkClient:
 		Args:
 			device_id: Device ID to control
 			action: "lock" or "unlock"
+			child_id: Child's user ID (optional, will use first supervised child if not provided)
 
 		Returns:
 			True if successful, False otherwise
@@ -671,7 +672,10 @@ class FamilyLinkClient:
 			cookie_header = self._get_cookie_header()
 
 			# Get supervised child account ID
-			account_id = await self.async_get_supervised_child_id()
+			if child_id is None:
+				account_id = await self.async_get_supervised_child_id()
+			else:
+				account_id = child_id
 
 			# Action codes discovered from browser DevTools:
 			# Code 1 = LOCK (verrouiller)

--- a/custom_components/familylink/coordinator.py
+++ b/custom_components/familylink/coordinator.py
@@ -316,7 +316,7 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 				_LOGGER.error(f"Could not determine child_id for device {device_id}")
 				return False
 
-			success = await self.client.async_control_device(device_id, action)
+			success = await self.client.async_control_device(device_id, action, child_id)
 
 			if success:
 				_LOGGER.info(f"Successfully {action}ed device {device_id}")


### PR DESCRIPTION
The device lock/unlock functionality was failing with INVALID_ARGUMENT error when trying to control devices for families with multiple supervised children. The issue was that async_control_device() was always using the first child's ID instead of the correct child's ID for the device.

Changes:
- Updated async_control_device() in api.py to accept optional child_id parameter
- Modified coordinator to pass child_id when calling device control API
- Now correctly uses the device owner's child_id for lock/unlock operations

Fixes the 400 error: "Request contains an invalid argument"