### PR TITLE
docs: Clarify VNC requirement and improve documentation consistency

### DIFF
--- a/DOCKER_STANDALONE.md
+++ b/DOCKER_STANDALONE.md
@@ -43,15 +43,17 @@ docker-compose up -d
 
 5. **Authenticate with Google:**
    - Click "Start Authentication"
-   - If the window doesn't open, connect via VNC (see below)
+   - **Important**: The browser opens inside the Docker container, not on your computer
+   - **You must connect via VNC** to see and interact with the browser
 
-6. **Access via VNC (if needed):**
-   - VNC Server: `vnc://localhost:5900`
+6. **Access via VNC (Required):**
+   - VNC Server: `vnc://localhost:5900` (or `vnc://YOUR_SERVER_IP:5900`)
    - Password: `familylink`
    - Recommended VNC clients:
-     - **macOS**: Built-in Screen Sharing or RealVNC Viewer
+     - **macOS**: Built-in Screen Sharing (Finder → Go → Connect to Server) or RealVNC Viewer
      - **Windows**: TightVNC Viewer, RealVNC Viewer
      - **Linux**: Remmina, TigerVNC Viewer
+   - Once connected, you'll see the Chromium browser with Google login page
 
 ### Option 2: Using Docker Run
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ See the detailed [Installation Guide](INSTALL.md) for step-by-step instructions.
 [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fnoiwid%2FHAFamilyLink)
    - Add repository to Home Assistant
    - Install and start the add-on
-   - Authenticate via Web UI
+   - Authenticate via Web UI (requires VNC client - see [Installation Guide](INSTALL.md))
 
 2. **Install Integration**
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=Noiwid&repository=HAFamilyLink&category=integration)

--- a/familylink-playwright/Dockerfile
+++ b/familylink-playwright/Dockerfile
@@ -73,4 +73,4 @@ LABEL \
     io.hass.name="Google Family Link Auth" \
     io.hass.description="Authentication service for Google Family Link" \
     io.hass.type="addon" \
-    io.hass.version="1.1.1"
+    io.hass.version="1.2.3"


### PR DESCRIPTION
Major improvements:
- Clarified that browser opens INSIDE Docker container, not on user's computer
- Made VNC requirement explicit in all documentation
- Added VNC client recommendations (macOS, Windows, Linux)
- Improved troubleshooting sections with VNC instructions

Documentation updates:
- familylink-playwright/README.md: Added VNC to features, usage, and troubleshooting
- DOCKER_STANDALONE.md: Clarified VNC is required (not optional)
- README.md: Added VNC note in quick start
- Updated addon version numbers to 1.2.3 (sync with config.json)

Architecture clarification:
- Explained Xvfb virtual display + x11vnc setup
- Documented why VNC is necessary for authentication

This addresses user confusion where they expected a browser window to open on their local machine via window.open().