### PR TITLE
fix: Add standalone Dockerfile to resolve bashio errors (#28)

### DIFF
--- a/DOCKER_STANDALONE.md
+++ b/DOCKER_STANDALONE.md
@@ -15,27 +15,48 @@ The Family Link Auth addon can run as a standalone Docker container, making it c
 - Docker Compose (optional, but recommended)
 - Network access from your Home Assistant instance to the addon container
 
+## ⚠️ Important Note
+
+The standalone deployment uses a **different Dockerfile** (`Dockerfile.standalone`) than the Home Assistant Supervisor addon. This is because:
+- The addon version uses Home Assistant's `bashio` tools which don't work outside Supervisor
+- The standalone version uses a clean Debian base and standard bash scripts
+- **If you see errors about `bashio` or `s6-rc`, you're using the wrong image!**
+
 ## 🚀 Quick Start
 
 ### Option 1: Using Docker Compose (Recommended)
 
-1. **Download the docker-compose file:**
+1. **Clone the repository or download the standalone files:**
 
 ```bash
-curl -o docker-compose.yml https://raw.githubusercontent.com/noiwid/HAFamilyLink/main/familylink-playwright/docker-compose.standalone.yml
+# Option A: Clone the repository
+git clone https://github.com/noiwid/HAFamilyLink.git
+cd HAFamilyLink/familylink-playwright
+
+# Option B: Download just the necessary files
+mkdir familylink-auth && cd familylink-auth
+curl -O https://raw.githubusercontent.com/noiwid/HAFamilyLink/main/familylink-playwright/docker-compose.standalone.yml
+curl -O https://raw.githubusercontent.com/noiwid/HAFamilyLink/main/familylink-playwright/Dockerfile.standalone
+curl -O https://raw.githubusercontent.com/noiwid/HAFamilyLink/main/familylink-playwright/run-standalone.sh
+curl -O https://raw.githubusercontent.com/noiwid/HAFamilyLink/main/familylink-playwright/requirements.txt
+# Download the app directory
+curl -L https://github.com/noiwid/HAFamilyLink/archive/refs/heads/main.zip -o repo.zip
+unzip repo.zip "HAFamilyLink-main/familylink-playwright/app/*" && mv HAFamilyLink-main/familylink-playwright/app . && rm -rf HAFamilyLink-main repo.zip
 ```
 
 2. **Create data directory:**
 
 ```bash
-mkdir -p ./familylink-data
+mkdir -p ./data
 ```
 
-3. **Start the container:**
+3. **Build and start the container:**
 
 ```bash
-docker-compose up -d
+docker-compose -f docker-compose.standalone.yml up -d --build
 ```
+
+This will build the image locally using `Dockerfile.standalone` which doesn't use bashio.
 
 4. **Access the web interface:**
    - Open: http://localhost:8099
@@ -229,7 +250,26 @@ docker buildx build \
 
 ## 🛠️ Troubleshooting
 
-### Container Won't Start
+### "bashio: unbound variable" or "s6-rc failed" Errors
+
+**Symptom**: Container fails to start with errors like:
+```
+/usr/lib/bashio/log.sh: line 107: info: unbound variable
+s6-rc: warning: unable to start service base-addon-banner: command exited 1
+```
+
+**Cause**: You're using the Home Assistant Supervisor addon image (`ghcr.io/noiwid/familylink-auth:latest`) instead of the standalone image.
+
+**Solution**: Build the standalone image locally:
+
+```bash
+cd familylink-playwright
+docker-compose -f docker-compose.standalone.yml up -d --build
+```
+
+This uses `Dockerfile.standalone` which doesn't require Home Assistant Supervisor or bashio.
+
+### Container Won't Start (Other Reasons)
 
 ```bash
 # Check logs

--- a/familylink-playwright/Dockerfile.standalone
+++ b/familylink-playwright/Dockerfile.standalone
@@ -1,0 +1,82 @@
+FROM debian:12-slim
+
+# Set shell
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install system dependencies required for Playwright and Chromium
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 \
+        python3-pip \
+        python3-dev \
+        curl \
+        nodejs \
+        npm \
+        ca-certificates \
+        fonts-liberation \
+        libnss3 \
+        libatk-bridge2.0-0 \
+        libdrm2 \
+        libxkbcommon0 \
+        libxcomposite1 \
+        libxdamage1 \
+        libxfixes3 \
+        libxrandr2 \
+        libgbm1 \
+        libasound2 \
+        xvfb \
+        x11vnc \
+        fluxbox \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set environment variables for Playwright
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
+ENV PYTHONUNBUFFERED=1
+
+# Default environment variables (can be overridden)
+ENV LOG_LEVEL=info
+ENV AUTH_TIMEOUT=300
+ENV SESSION_DURATION=86400
+ENV VNC_PASSWORD=familylink
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir --break-system-packages -r requirements.txt
+
+# Install Playwright and its browsers
+# Debian-based image supports Playwright on ARM64
+RUN pip3 install --no-cache-dir --break-system-packages playwright && \
+    playwright install --with-deps chromium
+
+# Copy application code
+COPY app/ /app/app/
+
+# Copy standalone startup script
+COPY run-standalone.sh /usr/local/bin/run-standalone.sh
+RUN chmod +x /usr/local/bin/run-standalone.sh
+
+# Create necessary directories
+RUN mkdir -p /share/familylink && \
+    chmod 755 /share/familylink
+
+# Expose ports
+EXPOSE 8099 5900
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:8099/api/health || exit 1
+
+# Labels
+LABEL \
+    org.opencontainers.image.title="Google Family Link Auth (Standalone)" \
+    org.opencontainers.image.description="Standalone authentication service for Google Family Link" \
+    org.opencontainers.image.version="1.2.3" \
+    org.opencontainers.image.source="https://github.com/noiwid/HAFamilyLink"
+
+# Start the service
+CMD ["/usr/local/bin/run-standalone.sh"]

--- a/familylink-playwright/docker-compose.standalone.yml
+++ b/familylink-playwright/docker-compose.standalone.yml
@@ -2,7 +2,12 @@ version: '3.8'
 
 services:
   familylink-auth:
-    image: ghcr.io/noiwid/familylink-auth:latest
+    # Build from standalone Dockerfile instead of pulling pre-built image
+    build:
+      context: .
+      dockerfile: Dockerfile.standalone
+    # Alternatively, use pre-built standalone image when available:
+    # image: ghcr.io/noiwid/familylink-auth:standalone
     container_name: familylink-auth
     ports:
       - "8099:8099"  # Web interface

--- a/familylink-playwright/run-standalone.sh
+++ b/familylink-playwright/run-standalone.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -e
+
+# ==============================================================================
+# Start Family Link Auth Service (Standalone)
+# ==============================================================================
+
+echo "=============================================="
+echo "Google Family Link Auth Service (Standalone)"
+echo "=============================================="
+echo ""
+
+# Read configuration from environment variables
+LOG_LEVEL="${LOG_LEVEL:-info}"
+AUTH_TIMEOUT="${AUTH_TIMEOUT:-300}"
+SESSION_DURATION="${SESSION_DURATION:-86400}"
+VNC_PASSWORD="${VNC_PASSWORD:-familylink}"
+
+echo "Configuration:"
+echo "  - Log Level: ${LOG_LEVEL}"
+echo "  - Auth Timeout: ${AUTH_TIMEOUT}s"
+echo "  - Session Duration: ${SESSION_DURATION}s"
+echo "  - VNC Password: ${VNC_PASSWORD}"
+echo ""
+
+# Ensure shared directory exists
+mkdir -p /share/familylink
+chmod 755 /share/familylink
+echo "✓ Shared storage ready at /share/familylink"
+
+# Start Xvfb (virtual display)
+echo "Starting virtual display (Xvfb)..."
+Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &
+export DISPLAY=:99
+
+# Wait for Xvfb to start
+sleep 2
+echo "✓ Virtual display started on :99"
+
+# Start window manager
+fluxbox >/dev/null 2>&1 &
+echo "✓ Window manager (fluxbox) started"
+
+# Start VNC server for remote access
+echo "Starting VNC server on port 5900..."
+x11vnc -display :99 -forever -shared -rfbport 5900 -passwd "${VNC_PASSWORD}" >/dev/null 2>&1 &
+echo "✓ VNC server started (password: ${VNC_PASSWORD})"
+echo ""
+
+echo "=============================================="
+echo "Service Ready!"
+echo "  - Web UI: http://localhost:8099"
+echo "  - VNC:    vnc://localhost:5900"
+echo "=============================================="
+echo ""
+
+# Start the FastAPI application with uvicorn
+cd /app || exit 1
+exec uvicorn app.main:app \
+    --host 0.0.0.0 \
+    --port 8099 \
+    --log-level "${LOG_LEVEL}" \
+    --no-access-log \
+    --workers 1


### PR DESCRIPTION
The standalone Docker deployment was failing with bashio errors because it was using the Home Assistant Supervisor addon image which requires bashio and s6-rc tools that don't work outside Supervisor.

Changes:
- Added Dockerfile.standalone: Clean Debian-based image without bashio
- Added run-standalone.sh: Startup script using standard bash (no bashio)
- Updated docker-compose.standalone.yml: Now builds locally from Dockerfile.standalone
- Updated DOCKER_STANDALONE.md:
  * Added warning about bashio errors
  * Updated setup instructions to build locally
  * Added troubleshooting section for bashio/s6-rc errors
  * Clarified difference between addon and standalone images

Technical details:
- Standalone uses debian:12-slim base instead of hassio-addons/debian-base
- Environment variables read directly instead of via bashio::config
- Standard echo instead of bashio::log.info
- No s6 init system required

Fixes #28