### PR TITLE
fix: Use dynamic day code in set_daily_limit service (#32)

### DIFF
--- a/custom_components/familylink/manifest.json
+++ b/custom_components/familylink/manifest.json
@@ -1,7 +1,7 @@
 {
 	"domain": "familylink",
 	"name": "Google Family Link",
-	"version": "0.9.2",
+	"version": "0.9.3",
 	"documentation": "https://github.com/noiwid/HAFamilyLink",
 	"issue_tracker": "https://github.com/noiwid/HAFamilyLink/issues",
 	"codeowners": ["@noiwid"],


### PR DESCRIPTION
The set_daily_limit service was using a hardcoded "CAEQBg" (Saturday) day code instead of the current day of the week. This caused the API to create an override for Saturday regardless of which day it was called, resulting in no visible change to the daily limit for the current day.

Now dynamically determines the current day and uses the correct CAEQ code:
- CAEQAQ (Monday) through CAEQBw (Sunday)

Fixes #32