### PR TITLE
docs: update documentation for v0.9.8 battery level support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.9.8] - 2025-01
+
+### Added
+- **Battery Level Sensor** - New `sensor.<child>_battery_level` entity (#54)
+  - Displays battery percentage of the device providing location data
+  - Dynamic icon based on battery level (full → alert)
+  - Attributes: `source_device`, `last_update`
+  - Also available as `battery_level` attribute on device tracker entity
+
+### Important Limitations
+- **Requires location tracking**: Battery data comes from the location API endpoint
+- **One device per child**: Battery level corresponds to the device selected for location tracking in Family Link app (see "Change device" screen), not all devices
+- **Charging state**: The API returns what appears to be a charging state value, but it has not been confirmed yet and is disabled until validated
+
+---
+
 ## [0.9.7] - 2025-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This integration uses unofficial, reverse-engineered Google Family Link API endp
 - **Place Detection** - Automatically shows when child is at a saved place (Home, School, etc.)
 - **Address Display** - Full address of current location
 - **Source Device** - Shows which device provided the location
+- **Battery Level** - Monitor battery percentage of the location source device
 - **Privacy First** - Disabled by default, opt-in via configuration
 - **⚠️ Warning** - Each location poll may notify the child's device
 
@@ -67,7 +68,18 @@ This integration uses unofficial, reverse-engineered Google Family Link API endp
     - `place_name` - Saved place name (e.g., "Home", "School")
     - `address` - Full address of the location
     - `location_timestamp` - When the location was captured
+    - `battery_level` - Battery percentage of source device
   - **Note**: Requires enabling "GPS location tracking" in integration config
+
+#### Battery Sensor (GPS Location - Optional)
+- `sensor.<child>_battery_level` - Battery level of location source device
+  - **State**: Battery percentage (0-100%)
+  - **Device Class**: `battery`
+  - **Attributes**:
+    - `source_device` - Device name providing the battery data
+    - `last_update` - Timestamp of last update
+  - **Note**: Requires enabling "GPS location tracking" in integration config
+  - **⚠️ Limitation**: Shows battery of the device selected for location tracking in Family Link app, not all devices
 
 #### Switches (Global Controls)
 - `switch.<child>_bedtime` - Enable/disable bedtime restrictions
@@ -423,6 +435,11 @@ automation:
 ```
 
 ## 📈 Version History
+
+- **v0.9.8** (2025-01) - Battery Level Support
+  - **Battery Level Sensor** - Monitor battery % of location source device
+  - Requires location tracking to be enabled
+  - Shows battery of the device selected for location in Family Link app
 
 - **v0.9.4** (2025-11) - GPS Location & Docker Standalone
   - **GPS Device Tracker** - Track child location via `device_tracker` entity

--- a/custom_components/familylink/manifest.json
+++ b/custom_components/familylink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "familylink",
   "name": "Google Family Link",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "documentation": "https://github.com/noiwid/HAFamilyLink",
   "issue_tracker": "https://github.com/noiwid/HAFamilyLink/issues",
   "codeowners": [


### PR DESCRIPTION
- CHANGELOG.md: Add v0.9.8 release notes with battery feature and limitations
- README.md: Add battery level sensor to features and entities list
- manifest.json: Bump version to 0.9.8
- GOOGLE_FAMILY_LINK_API_ANALYSIS.md: Document location endpoint battery fields