### PR TITLE
fix: add missing translations for OptionsFlow

### DIFF
--- a/custom_components/familylink/translations/en.json
+++ b/custom_components/familylink/translations/en.json
@@ -1,4 +1,21 @@
 {
+	"options": {
+		"step": {
+			"init": {
+				"title": "Configure Family Link",
+				"description": "Adjust integration settings. Changes will take effect after saving.",
+				"data": {
+					"update_interval": "Update Interval (seconds)",
+					"timeout": "Request Timeout (seconds)",
+					"enable_location_tracking": "Enable GPS location tracking"
+				},
+				"data_description": {
+					"update_interval": "How often to fetch data from Google (30-3600 seconds)",
+					"enable_location_tracking": "When enabled, each location poll may send a notification to the child's device"
+				}
+			}
+		}
+	},
 	"config": {
 		"step": {
 			"user": {

--- a/custom_components/familylink/translations/fr.json
+++ b/custom_components/familylink/translations/fr.json
@@ -1,4 +1,21 @@
 {
+	"options": {
+		"step": {
+			"init": {
+				"title": "Configurer Family Link",
+				"description": "Modifier les paramètres de l'intégration. Les changements prendront effet après la sauvegarde.",
+				"data": {
+					"update_interval": "Intervalle de mise à jour (secondes)",
+					"timeout": "Délai d'expiration des requêtes (secondes)",
+					"enable_location_tracking": "Activer le suivi GPS"
+				},
+				"data_description": {
+					"update_interval": "Fréquence de récupération des données depuis Google (30-3600 secondes)",
+					"enable_location_tracking": "Lorsque activé, chaque interrogation de position peut envoyer une notification sur l'appareil de l'enfant"
+				}
+			}
+		}
+	},
 	"config": {
 		"step": {
 			"user": {


### PR DESCRIPTION
Added the "options" section to translation files:
- translations/en.json: English translations for options flow
- translations/fr.json: French translations for options flow

This fixes the options dialog showing raw keys instead of human-readable labels.