### PR TITLE
fix: improve browser stability for virtualized environments

### DIFF
--- a/familylink-playwright/docker-compose.standalone.yml
+++ b/familylink-playwright/docker-compose.standalone.yml
@@ -14,6 +14,8 @@ services:
       - "5900:5900"  # VNC server
     volumes:
       - ./data:/share/familylink:rw
+    # Increase shared memory size for Chromium (default 64MB is too small)
+    shm_size: '2gb'
     environment:
       - LOG_LEVEL=info
       - AUTH_TIMEOUT=300


### PR DESCRIPTION
- Add GPU-disable flags to prevent "Aw, Snap!" crashes in VMs (VirtualBox, VMware, etc.) where hardware acceleration is unavailable
- Change wait_until strategy from 'networkidle' to 'load' for better reliability on pages with continuous background requests
- Add shm_size to docker-compose.standalone.yml for sufficient shared memory for Chromium

Fixes #68