### PR TITLE
fix: remove single-process flag causing segfault in HA add-on

### DIFF
--- a/familylink-playwright/app/auth/browser.py
+++ b/familylink-playwright/app/auth/browser.py
@@ -35,7 +35,7 @@ class BrowserAuthManager:
         try:
             # Launch browser (non-headless so user can interact)
             # Extensive flags for virtualized/nested VM environments (VirtualBox, VMware, etc.)
-            # These prevent "Aw, Snap!" crashes caused by GPU acceleration and resource constraints
+            # These prevent crashes caused by GPU acceleration and missing system services
             browser = await self._playwright.chromium.launch(
                 headless=False,
                 args=[
@@ -53,10 +53,10 @@ class BrowserAuthManager:
                     '--disable-accelerated-video-decode',
                     '--disable-accelerated-video-encode',
                     '--disable-features=VizDisplayCompositor',
-                    '--use-gl=swiftshader',
-                    # Process model - single process is more stable in constrained environments
-                    '--single-process',
-                    '--no-zygote',
+                    # System services - disable D-Bus to avoid missing socket errors
+                    '--disable-features=dbus',
+                    '--disable-breakpad',
+                    '--disable-component-update',
                     # Anti-detection
                     '--disable-blink-features=AutomationControlled',
                     '--disable-features=IsolateOrigins,site-per-process',


### PR DESCRIPTION
The --single-process and --no-zygote flags were causing segmentation faults (Signal 11) in the Home Assistant add-on environment due to missing D-Bus socket and GLib schema issues.

Changes:
- Remove --single-process and --no-zygote flags
- Remove --use-gl=swiftshader (can cause instability)
- Add --disable-features=dbus to avoid D-Bus dependency
- Add --disable-breakpad and --disable-component-update

Ref #68