### PR TITLE
Replace x11vnc with noVNC for web-based browser access

### DIFF
--- a/familylink-playwright/Dockerfile
+++ b/familylink-playwright/Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get update \
         xvfb \
         x11vnc \
         fluxbox \
+        novnc \
+        python3-websockify \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -62,7 +64,7 @@ RUN mkdir -p /share/familylink && \
     chmod 700 /share/familylink
 
 # Expose ports
-EXPOSE 8099 5900
+EXPOSE 8099 6080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \

--- a/familylink-playwright/Dockerfile.standalone
+++ b/familylink-playwright/Dockerfile.standalone
@@ -27,6 +27,8 @@ RUN apt-get update \
         xvfb \
         x11vnc \
         fluxbox \
+        novnc \
+        python3-websockify \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -65,7 +67,7 @@ RUN mkdir -p /share/familylink && \
     chmod 755 /share/familylink
 
 # Expose ports
-EXPOSE 8099 5900
+EXPOSE 8099 6080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \

--- a/familylink-playwright/config.json
+++ b/familylink-playwright/config.json
@@ -10,11 +10,11 @@
   "init": false,
   "ports": {
     "8099/tcp": 8099,
-    "5900/tcp": 5900
+    "6080/tcp": 6080
   },
   "ports_description": {
     "8099/tcp": "Web interface for Google authentication",
-    "5900/tcp": "VNC server for browser access"
+    "6080/tcp": "noVNC web interface for browser access"
   },
   "map": ["share:rw"],
   "options": {

--- a/familylink-playwright/docker-compose.standalone.yml
+++ b/familylink-playwright/docker-compose.standalone.yml
@@ -11,7 +11,7 @@ services:
     container_name: familylink-auth
     ports:
       - "8099:8099"  # Web interface
-      - "5900:5900"  # VNC server
+      - "6080:6080"  # noVNC web interface
     volumes:
       - ./data:/share/familylink:rw
     # Increase shared memory size for Chromium (default 64MB is too small)

--- a/familylink-playwright/rootfs/usr/local/bin/run.sh
+++ b/familylink-playwright/rootfs/usr/local/bin/run.sh
@@ -38,10 +38,14 @@ sleep 2
 # Start window manager
 fluxbox &
 
-# Start VNC server for remote access
-bashio::log.info "Starting VNC server on port 5900..."
-bashio::log.info "VNC password: familylink"
-x11vnc -display :99 -forever -shared -rfbport 5900 -passwd familylink &
+# Start VNC server (localhost only, used by noVNC)
+bashio::log.info "Starting VNC backend on localhost:5900..."
+x11vnc -display :99 -forever -shared -rfbport 5900 -passwd familylink -localhost &
+
+# Start noVNC (web-based VNC viewer)
+bashio::log.info "Starting noVNC on port 6080..."
+websockify --web=/usr/share/novnc 6080 localhost:5900 &
+bashio::log.info "noVNC available at http://[HOST]:6080/vnc.html"
 
 bashio::log.info "Starting FastAPI application..."
 

--- a/familylink-playwright/run-standalone.sh
+++ b/familylink-playwright/run-standalone.sh
@@ -42,16 +42,21 @@ echo "✓ Virtual display started on :99"
 fluxbox >/dev/null 2>&1 &
 echo "✓ Window manager (fluxbox) started"
 
-# Start VNC server for remote access
-echo "Starting VNC server on port 5900..."
-x11vnc -display :99 -forever -shared -rfbport 5900 -passwd "${VNC_PASSWORD}" >/dev/null 2>&1 &
-echo "✓ VNC server started (password: ${VNC_PASSWORD})"
+# Start VNC server (localhost only, used by noVNC)
+echo "Starting VNC backend on localhost:5900..."
+x11vnc -display :99 -forever -shared -rfbport 5900 -passwd "${VNC_PASSWORD}" -localhost >/dev/null 2>&1 &
+echo "✓ VNC backend started"
+
+# Start noVNC (web-based VNC viewer)
+echo "Starting noVNC on port 6080..."
+websockify --web=/usr/share/novnc 6080 localhost:5900 >/dev/null 2>&1 &
+echo "✓ noVNC started"
 echo ""
 
 echo "=============================================="
 echo "Service Ready!"
-echo "  - Web UI: http://localhost:8099"
-echo "  - VNC:    vnc://localhost:5900"
+echo "  - Web UI:  http://localhost:8099"
+echo "  - Browser: http://localhost:6080/vnc.html"
 echo "=============================================="
 echo ""
 


### PR DESCRIPTION
## Summary
- Replace external VNC client requirement with browser-based noVNC viewer on port 6080
- x11vnc now binds to localhost only (no longer externally exposed on port 5900)
- websockify bridges WebSocket traffic from noVNC to the local VNC backend
- Users simply open `http://<host>:6080/vnc.html` instead of needing TightVNC/RealVNC

## Test plan
- [ ] Build Docker image from `Dockerfile.standalone` and verify noVNC loads at `http://localhost:6080/vnc.html`
- [ ] Confirm Chromium browser session is visible and interactive through the web viewer
- [ ] Verify port 5900 is NOT accessible from outside the container
- [ ] Test Google login flow end-to-end through the noVNC web interface
- [ ] Verify HA addon build with `Dockerfile` works with updated `config.json` port mappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)