### PR TITLE
docs: clarify that both ports 8099 and 6080 must be accessible

### DIFF
--- a/familylink-playwright/DOCS.md
+++ b/familylink-playwright/DOCS.md
@@ -74,15 +74,21 @@ session_duration: 86400  # Cookies valid for 24 hours
 
 ### Step 4: Authenticate
 
-1. Click **Open Web UI** or navigate to `http://[YOUR_HA]:8099`
-2. Click "Démarrer l'authentification"
+> **Important: Two ports are required!**
+> - **Port 8099**: Web UI (start authentication, check status)
+> - **Port 6080**: noVNC (interact with the Google login browser)
+>
+> Both ports must be accessible from your browser. If you access Home Assistant via a reverse proxy or external domain, make sure both ports are forwarded, or use your HA's **local IP** (e.g. `http://192.168.1.x:8099` and `http://192.168.1.x:6080`).
+
+1. Click **Open Web UI** or navigate to `http://[YOUR_HA_LOCAL_IP]:8099`
+2. Click "Start Authentication"
 3. The browser launches inside the container - connect via noVNC to interact with it:
-   - Open `http://[YOUR_HA]:6080/vnc.html` in your web browser
+   - Open `http://[YOUR_HA_LOCAL_IP]:6080/vnc.html` in your web browser
    - Password: `familylink`
    - Click **Connect** (no VNC client software needed)
 4. Sign in to Google in the noVNC browser window
-5. Complete 2FA if required
-6. Wait for success message
+5. Complete 2FA if prompted
+6. Wait for the success message
 7. Close the noVNC browser tab
 
 ### Step 5: Configure Integration

--- a/familylink-playwright/README.md
+++ b/familylink-playwright/README.md
@@ -63,10 +63,14 @@ This add-on runs a web server with Playwright browser automation to handle Googl
    - Or navigate to port 8099 in your browser
 
 3. **Authenticate**:
-   - Click "Démarrer l'authentification" (Start Authentication)
+   - Click "Start Authentication"
    - **Important**: The browser opens **inside the Docker container**, not on your computer
+   - **Two ports are required** — both must be accessible from your browser:
+     - **Port 8099**: Web UI (authentication controls)
+     - **Port 6080**: noVNC (browser interaction)
+   - If you use a reverse proxy or external domain, use your HA's **local IP** instead (e.g. `192.168.1.x`)
    - **To see and interact with the browser**, connect via noVNC in your web browser:
-     - Open `http://[YOUR_HA_IP]:6080/vnc.html`
+     - Open `http://[YOUR_HA_LOCAL_IP]:6080/vnc.html`
      - **Password**: `familylink`
      - Click **Connect**
      - No VNC client software is needed - it runs directly in your browser!


### PR DESCRIPTION
Add prominent warnings in README and DOCS about the two-port requirement for noVNC-based authentication. Users behind reverse proxies should use their HA local IP instead of external domain.

https://claude.ai/code/session_01Ec9iAnvFh6D2D52weiHubc