### PR TITLE
fix: revert locationRefreshMode to string values (v1.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.2.2] - 2025-03-16
+
+### Fixed
+- **Revert `locationRefreshMode` to string values** — v1.2.1 incorrectly changed `locationRefreshMode` from string (`"REFRESH"` / `"DO_NOT_REFRESH"`) to numeric (`1` / `0`), which broke location tracking and battery level for all users. Reverted to the original string values expected by the Google Kids Management API (#89)
+
+---
+
 ## [1.2.1] - 2025-03-15
 
 ### Fixed
-- **`refresh_location` service returning HTTP 400** — The Google Kids Management API expects numeric protobuf enum values for `locationRefreshMode` (`1` = refresh, `0` = do not refresh). The previous string values (`"REFRESH"`, `"DO_NOT_REFRESH"`) caused `INVALID_ARGUMENT` errors (#84)
+- **`refresh_location` service returning HTTP 400** — *(Reverted in v1.2.2)* Changed `locationRefreshMode` to numeric values, which turned out to be incorrect (#84)
 
 ---
 

--- a/custom_components/familylink/client/api.py
+++ b/custom_components/familylink/client/api.py
@@ -596,7 +596,7 @@ class FamilyLinkClient:
 			self._validate_id(account_id, "account_id")
 			url = f"{self.BASE_URL}/families/mine/location/{account_id}"
 			params = [
-				("locationRefreshMode", 1 if refresh else 0),
+				("locationRefreshMode", "REFRESH" if refresh else "DO_NOT_REFRESH"),
 				("supportedConsents", "SUPERVISED_LOCATION_SHARING"),
 			]
 

--- a/custom_components/familylink/manifest.json
+++ b/custom_components/familylink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "familylink",
   "name": "Google Family Link",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "documentation": "https://github.com/noiwid/HAFamilyLink",
   "issue_tracker": "https://github.com/noiwid/HAFamilyLink/issues",
   "codeowners": [


### PR DESCRIPTION
v1.2.1 incorrectly changed locationRefreshMode from string to numeric values, breaking location tracking and battery level for all users. Revert to original "REFRESH"/"DO_NOT_REFRESH" strings. Fixes #89.

https://claude.ai/code/session_01Ec9iAnvFh6D2D52weiHubc