### PR TITLE
Fix schooltime whitelist not unblocking apps (#101)

### DIFF
--- a/custom_components/familylink/__init__.py
+++ b/custom_components/familylink/__init__.py
@@ -228,7 +228,7 @@ async def async_setup_services(hass: HomeAssistant, coordinator: FamilyLinkDataU
 				)
 				_LOGGER.info(
 					f"School mode activated for child {child_id}: {result['blocked_count']} apps blocked, "
-					f"{result['failed_count']} failed"
+					f"{result.get('unblocked_count', 0)} unblocked, {result['failed_count']} failed"
 				)
 			else:
 				_LOGGER.info("Service called: block_device_for_school (all children)")
@@ -236,13 +236,16 @@ async def async_setup_services(hass: HomeAssistant, coordinator: FamilyLinkDataU
 				for child in children:
 					child_account_id = child["id"]
 					child_name = child["name"]
-					result = await coordinator.client.async_block_device_for_school(
-						account_id=child_account_id, whitelist=whitelist
-					)
-					_LOGGER.info(
-						f"School mode activated for {child_name}: {result['blocked_count']} apps blocked, "
-						f"{result['failed_count']} failed"
-					)
+					try:
+						result = await coordinator.client.async_block_device_for_school(
+							account_id=child_account_id, whitelist=whitelist
+						)
+						_LOGGER.info(
+							f"School mode activated for {child_name}: {result['blocked_count']} apps blocked, "
+							f"{result.get('unblocked_count', 0)} unblocked, {result['failed_count']} failed"
+						)
+					except Exception as child_err:
+						_LOGGER.error(f"Failed to block device for school for {child_name}: {child_err}")
 			await coordinator.async_request_refresh()
 		except Exception as err:
 			_LOGGER.error(f"Failed to block device for school: {err}")

--- a/custom_components/familylink/client/api.py
+++ b/custom_components/familylink/client/api.py
@@ -919,17 +919,34 @@ class FamilyLinkClient:
 
 		blocked = []
 		failed = []
+		unblocked = []
+
+		# Convert whitelist to a set for faster lookups
+		whitelist_set = set(whitelist)
 
 		for app in all_apps:
 			package_name = app.get("packageName", "")
+			is_blocked = app.get("supervisionSetting", {}).get("hidden", False)
 
-			# Skip if in whitelist
-			if package_name in whitelist:
-				_LOGGER.debug(f"Skipping whitelisted app: {package_name}")
+			if package_name in whitelist_set:
+				# Unblock whitelisted apps that are currently blocked
+				if is_blocked:
+					_LOGGER.debug(f"Unblocking whitelisted app: {package_name}")
+					success = await self.async_unblock_app(package_name, account_id)
+					if success:
+						unblocked.append({
+							"name": app.get("title", "Unknown"),
+							"package": package_name
+						})
+					else:
+						failed.append(package_name)
+					await asyncio.sleep(0.1)
+				else:
+					_LOGGER.debug(f"Skipping whitelisted app (already allowed): {package_name}")
 				continue
 
 			# Skip if already blocked
-			if app.get("supervisionSetting", {}).get("hidden", False):
+			if is_blocked:
 				_LOGGER.debug(f"App already blocked: {package_name}")
 				continue
 
@@ -947,13 +964,15 @@ class FamilyLinkClient:
 			await asyncio.sleep(0.1)
 
 		_LOGGER.info(
-			f"School mode activated: {len(blocked)} apps blocked, {len(failed)} failed, "
-			f"{len(whitelist)} apps whitelisted"
+			f"School mode activated: {len(blocked)} apps blocked, {len(unblocked)} unblocked, "
+			f"{len(failed)} failed, {len(whitelist)} apps whitelisted"
 		)
 
 		return {
 			"blocked_count": len(blocked),
 			"blocked_apps": blocked,
+			"unblocked_count": len(unblocked),
+			"unblocked_apps": unblocked,
 			"failed_count": len(failed),
 			"failed_apps": failed,
 			"whitelisted_count": len(whitelist),

--- a/custom_components/familylink/services.yaml
+++ b/custom_components/familylink/services.yaml
@@ -6,11 +6,14 @@ block_device_for_school:
   fields:
     whitelist:
       name: Additional Whitelist
-      description: Additional package names to keep allowed (beyond the default essential apps)
+      description: Additional package names to keep allowed (beyond the default essential apps). Enter one package name per line.
       required: false
-      example: "com.example.educationalapp"
+      example:
+        - "com.example.educationalapp"
+        - "com.microsoft.teams"
       selector:
-        object:
+        text:
+          multiple: true
     entity_id:
       name: Child Entity
       description: Select any Family Link entity for this child (optional - if not specified, applies to ALL children)


### PR DESCRIPTION
## Summary

- **Root cause fix**: Whitelisted apps that were already blocked were never actively unblocked — the code just skipped them. Now `block_device_for_school` will call `async_unblock_app()` on any whitelisted app that is currently blocked.
- **services.yaml**: Changed the whitelist selector from `object:` to `text: multiple: true` for proper list-of-strings input in the HA UI.
- **Error handling**: When applying school mode to all children, a failure on one child no longer prevents processing the others.

Closes #101

## Test plan

- [ ] Call `block_device_for_school` with a whitelist containing an app that is **already blocked** → it should be unblocked
- [ ] Call `block_device_for_school` with a whitelist containing an app that is **not blocked** → it should remain allowed
- [ ] Call without whitelist → behavior unchanged (only default essential apps whitelisted)
- [ ] Verify the service UI in HA shows a proper multi-text input for the whitelist field