### PR TITLE
Fix standalone Docker config flow and noVNC black screen (#108, #109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.2.6-rc2] - 2026-05-12
+
+### Fixed
+- **Config flow now exposes "Manual URL configuration" explicitly** — Previously the manual URL form was only reachable when local auto-detection failed, which made it impossible for Docker standalone users to point the integration at a remote auth container if `/share/familylink/` happened to contain stale data from a previous add-on install (#109)
+- **Standalone container no longer shows a black noVNC screen** — A welcome banner is now displayed on the Xvfb display via `xterm` so users connecting to noVNC before triggering the auth flow get clear instructions instead of an empty desktop (#108)
+
+### Changed
+- `DOCKER_STANDALONE.md` rewritten to document the actual flow (open port 8099 first, then noVNC on port 6080) and the new menu option
+
+---
+
 ## [1.2.2] - 2025-03-16
 
 ### Fixed

--- a/DOCKER_STANDALONE.md
+++ b/DOCKER_STANDALONE.md
@@ -109,16 +109,28 @@ The `dns` entries (`8.8.8.8`, `8.8.4.4`) ensure the container can resolve Google
 
 ## Authentication
 
-1. Open the noVNC interface at `http://<your-docker-host>:6080`
-2. Enter the VNC password (default: `familylink`)
-3. Complete the Google login in the browser window
-4. Once authenticated, cookies are saved and the API becomes available
+The authentication flow uses **two ports**:
+- Port **8099** — the Web UI where you trigger the auth flow
+- Port **6080** — the noVNC window where you complete the Google login
+
+Order matters:
+
+1. Open the **Web UI** in your browser: `http://<your-docker-host>:8099`
+2. Click **"Start Authentication"** — this launches a Chromium browser inside the container
+3. Open the **noVNC** interface in a separate tab: `http://<your-docker-host>:6080/vnc.html`
+4. Enter the VNC password (default: `familylink`)
+5. Complete the Google login in the Chromium window shown via noVNC
+6. Once authenticated, cookies are saved automatically and the API becomes available
+
+> **Note:** If you open noVNC before clicking "Start Authentication", you will see a
+> welcome banner with the instructions instead of the Google login page — that is
+> normal, the browser has not been launched yet.
 
 ## Connecting to Home Assistant
 
 1. Install the **Family Link** integration in Home Assistant (via HACS or manually)
 2. Go to **Settings > Devices & Services > Add Integration > Family Link**
-3. Select **"Manual URL configuration"**
+3. In the menu, pick **"Manual URL configuration (Docker standalone)"**
 4. Enter the auth server URL: `http://<your-docker-host>:8099`
 5. The integration will connect to the standalone container and retrieve authentication cookies
 

--- a/custom_components/familylink/config_flow.py
+++ b/custom_components/familylink/config_flow.py
@@ -80,10 +80,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 	async def async_step_user(
 		self, user_input: dict[str, Any] | None = None
 	) -> FlowResult:
-		"""Handle the initial step - detect auth source."""
+		"""Handle the initial step - present a menu to choose how to connect."""
 		from .auth.addon_client import AddonCookieClient
 
-		# Detect available auth source
+		# Detect available auth source (only used as a hint for the "auto" branch)
 		addon_client = AddonCookieClient(self.hass)
 		source_type, detected_url = await addon_client.detect_auth_source()
 
@@ -92,11 +92,21 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 		_LOGGER.debug(f"Detected auth source: {source_type}, URL: {detected_url}")
 
-		if source_type == "none":
-			# No auto-detection possible, ask for URL
-			return await self.async_step_manual_url()
+		# Always let the user choose between auto-detection and manual URL.
+		# This is critical for Docker standalone setups where localhost-based
+		# detection cannot reach the auth container running on another host.
+		return self.async_show_menu(
+			step_id="user",
+			menu_options=["auto_detect", "manual_url"],
+		)
 
-		# Auto-detected, proceed with standard form
+	async def async_step_auto_detect(
+		self, user_input: dict[str, Any] | None = None
+	) -> FlowResult:
+		"""Use the auto-detected authentication source."""
+		if self._detected_source == "none":
+			# Nothing was detected, fall back to the manual URL form
+			return await self.async_step_manual_url()
 		return await self.async_step_configure(user_input)
 
 	async def async_step_manual_url(

--- a/custom_components/familylink/manifest.json
+++ b/custom_components/familylink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "familylink",
   "name": "Google Family Link",
-  "version": "1.2.6-rc1",
+  "version": "1.2.6-rc2",
   "documentation": "https://github.com/noiwid/HAFamilyLink",
   "issue_tracker": "https://github.com/noiwid/HAFamilyLink/issues",
   "codeowners": [

--- a/custom_components/familylink/strings.json
+++ b/custom_components/familylink/strings.json
@@ -20,7 +20,11 @@
 		"step": {
 			"user": {
 				"title": "Google Family Link",
-				"description": "Detecting authentication source..."
+				"description": "Choose how to connect to the Family Link Auth service.",
+				"menu_options": {
+					"auto_detect": "Auto-detect (add-on or local file)",
+					"manual_url": "Manual URL configuration (Docker standalone)"
+				}
 			},
 			"manual_url": {
 				"title": "Authentication Server URL",

--- a/custom_components/familylink/translations/en.json
+++ b/custom_components/familylink/translations/en.json
@@ -20,7 +20,11 @@
 		"step": {
 			"user": {
 				"title": "Google Family Link",
-				"description": "Detecting authentication source..."
+				"description": "Choose how to connect to the Family Link Auth service.",
+				"menu_options": {
+					"auto_detect": "Auto-detect (add-on or local file)",
+					"manual_url": "Manual URL configuration (Docker standalone)"
+				}
 			},
 			"manual_url": {
 				"title": "Authentication Server URL",

--- a/custom_components/familylink/translations/fr.json
+++ b/custom_components/familylink/translations/fr.json
@@ -20,7 +20,11 @@
 		"step": {
 			"user": {
 				"title": "Google Family Link",
-				"description": "Détection de la source d'authentification..."
+				"description": "Choisissez comment vous connecter au service Family Link Auth.",
+				"menu_options": {
+					"auto_detect": "Détection automatique (module complémentaire ou fichier local)",
+					"manual_url": "Configuration manuelle de l'URL (Docker autonome)"
+				}
 			},
 			"manual_url": {
 				"title": "URL du serveur d'authentification",

--- a/custom_components/familylink/translations/he.json
+++ b/custom_components/familylink/translations/he.json
@@ -20,7 +20,11 @@
     "step": {
       "user": {
         "title": "Google Family Link",
-        "description": "מזהה מקור אימות..."
+        "description": "בחר כיצד להתחבר לשירות Family Link Auth.",
+        "menu_options": {
+          "auto_detect": "זיהוי אוטומטי (תוסף או קובץ מקומי)",
+          "manual_url": "הגדרת URL ידנית (Docker עצמאי)"
+        }
       },
       "manual_url": {
         "title": "כתובת שרת האימות",

--- a/familylink-playwright/CHANGELOG.md
+++ b/familylink-playwright/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Google Family Link Auth Add-on will be documented in this file.
 
+## [1.6.1] - 2026-05-12
+
+### Fixed
+- **noVNC welcome banner** — Display a clear welcome message on the Xvfb desktop via `xterm` so users connecting to noVNC before starting the auth flow no longer see a black screen (#108)
+
+### Changed
+- Added `xterm` to the base Dockerfile dependencies (both add-on and standalone images)
+
 ## [1.6.0] - 2025-03
 
 ### Added

--- a/familylink-playwright/Dockerfile
+++ b/familylink-playwright/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
         novnc \
         python3-websockify \
         fluxbox \
+        xterm \
         dbus \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -54,9 +55,11 @@ RUN pip3 install --no-cache-dir --break-system-packages playwright && \
 # Copy application code
 COPY app/ /app/app/
 COPY rootfs/ /
+COPY welcome-banner.sh /usr/local/bin/welcome-banner.sh
 
 # Set permissions
 RUN chmod a+x /usr/local/bin/run.sh && \
+    chmod a+x /usr/local/bin/welcome-banner.sh && \
     chmod a+x /etc/services.d/familylink/run && \
     chmod a+x /etc/services.d/familylink/finish
 
@@ -76,4 +79,4 @@ LABEL \
     io.hass.name="Google Family Link Auth" \
     io.hass.description="Authentication service for Google Family Link" \
     io.hass.type="addon" \
-    io.hass.version="1.6.0"
+    io.hass.version="1.6.1"

--- a/familylink-playwright/Dockerfile.standalone
+++ b/familylink-playwright/Dockerfile.standalone
@@ -29,6 +29,7 @@ RUN apt-get update \
         novnc \
         python3-websockify \
         fluxbox \
+        xterm \
         dbus \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -59,9 +60,10 @@ RUN pip3 install --no-cache-dir --break-system-packages playwright && \
 # Copy application code
 COPY app/ /app/app/
 
-# Copy standalone startup script
+# Copy standalone startup script and welcome banner helper
 COPY run-standalone.sh /usr/local/bin/run-standalone.sh
-RUN chmod +x /usr/local/bin/run-standalone.sh
+COPY welcome-banner.sh /usr/local/bin/welcome-banner.sh
+RUN chmod +x /usr/local/bin/run-standalone.sh /usr/local/bin/welcome-banner.sh
 
 # Create necessary directories
 RUN mkdir -p /share/familylink && \
@@ -78,7 +80,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
 LABEL \
     org.opencontainers.image.title="Google Family Link Auth (Standalone)" \
     org.opencontainers.image.description="Standalone authentication service for Google Family Link" \
-    org.opencontainers.image.version="1.6.0" \
+    org.opencontainers.image.version="1.6.1" \
     org.opencontainers.image.source="https://github.com/noiwid/HAFamilyLink"
 
 # Start the service

--- a/familylink-playwright/config.json
+++ b/familylink-playwright/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Google Family Link Auth",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "slug": "familylink-playwright",
   "description": "Authentication service for Google Family Link integration using browser automation",
   "url": "https://github.com/noiwid/HAFamilyLink",

--- a/familylink-playwright/rootfs/usr/local/bin/run.sh
+++ b/familylink-playwright/rootfs/usr/local/bin/run.sh
@@ -104,6 +104,12 @@ if ! kill -0 "${NOVNC_PID}" 2>/dev/null; then
     bashio::log.warning "websockify/noVNC failed to start on port 6080"
 fi
 
+# Display a welcome banner on the Xvfb display so noVNC is not black
+# before the user triggers the authentication flow (issue #108).
+if [ -x /usr/local/bin/welcome-banner.sh ]; then
+    /usr/local/bin/welcome-banner.sh || bashio::log.warning "Welcome banner failed to start (non-critical)"
+fi
+
 bashio::log.info "Starting FastAPI application..."
 
 # Start the FastAPI application with uvicorn directly

--- a/familylink-playwright/run-standalone.sh
+++ b/familylink-playwright/run-standalone.sh
@@ -73,6 +73,12 @@ if kill -0 "${NOVNC_PID}" 2>/dev/null; then
 else
     echo "⚠ noVNC (websockify) failed to start on port 6080"
 fi
+
+# Display a welcome banner on the Xvfb display so noVNC is not black
+# before the user triggers the authentication flow (issue #108).
+if [ -x /usr/local/bin/welcome-banner.sh ]; then
+    /usr/local/bin/welcome-banner.sh || echo "⚠ Welcome banner failed to start (non-critical)"
+fi
 echo ""
 
 echo "=============================================="

--- a/familylink-playwright/welcome-banner.sh
+++ b/familylink-playwright/welcome-banner.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Display a welcome banner on the Xvfb display so noVNC users see clear
+# instructions instead of a black screen before the auth flow is started.
+
+set -e
+
+# Require DISPLAY to be set (we expect Xvfb to be running on :99)
+DISPLAY="${DISPLAY:-:99}"
+export DISPLAY
+
+# Make sure xterm is installed; if not, exit silently (non-critical)
+if ! command -v xterm >/dev/null 2>&1; then
+    echo "xterm not installed, skipping welcome banner"
+    exit 0
+fi
+
+# Wait briefly for X server / window manager to settle
+sleep 1
+
+# Geometry: roughly centered on a 1280x1024 Xvfb display
+xterm \
+    -geometry 84x22+220+250 \
+    -fa "Liberation Mono" -fs 13 \
+    -bg "#0f172a" -fg "#22d3ee" -bd "#22d3ee" \
+    -title "Family Link Auth — Welcome" \
+    -e bash -c '
+cat <<MSG
+============================================================
+   Google Family Link — Authentication Service
+============================================================
+
+   noVNC is connected. The Google login window will appear
+   here AFTER you start the authentication flow.
+
+   STEP 1 — Open the Web UI in a separate browser tab:
+            http://<your-host>:8099
+
+   STEP 2 — Click  "Start Authentication"  on that page.
+
+   STEP 3 — Come back to THIS noVNC tab to complete the
+            Google login that appears.
+
+============================================================
+
+Tip: this welcome message will stay visible until Chromium
+opens. It is normal — nothing is broken.
+
+MSG
+# Keep the window open until the container stops
+while true; do sleep 3600; done
+' >/dev/null 2>&1 &
+
+echo "✓ Welcome banner launched on display ${DISPLAY}"


### PR DESCRIPTION
## Summary

Fixes two issues affecting Docker standalone users:

- **#109** — Config flow now opens with an explicit menu so users can pick **"Manual URL configuration"** even when `localhost` detection or a stale `/share/familylink/` directory makes auto-detection succeed incorrectly. Previously the manual URL form was unreachable in that case, leaving standalone users unable to point the integration at a remote auth container.
- **#108** — Standalone (and add-on) containers now display a welcome banner on the Xvfb desktop via `xterm`. noVNC users who connect before triggering the auth flow get clear step-by-step instructions instead of a black screen.

## Changes

- `custom_components/familylink/config_flow.py` — `async_step_user` now shows a menu (`async_show_menu`) with `auto_detect` / `manual_url`; new `async_step_auto_detect` falls back to manual URL if nothing is detected.
- `custom_components/familylink/strings.json` + `translations/{en,fr,he}.json` — added `menu_options`.
- `familylink-playwright/welcome-banner.sh` (new) — launches a centered `xterm` on `:99` with the auth instructions.
- `familylink-playwright/Dockerfile` + `Dockerfile.standalone` — install `xterm` and copy the helper.
- `familylink-playwright/run-standalone.sh` + `rootfs/usr/local/bin/run.sh` — call the welcome banner after websockify starts.
- `DOCKER_STANDALONE.md` — corrected the documented flow (port 8099 first, then noVNC on 6080) and the new menu entry.
- Versions: integration `1.2.6-rc1` → `1.2.6-rc2`, add-on `1.6.0` → `1.6.1`. Changelog entries added in both.

## Test plan

- [ ] Install integration on HA Container with a stale `/share/familylink/` directory → "Manual URL configuration" entry is selectable from the new menu.
- [ ] Install integration on HA OS with the add-on running → "Auto-detect" menu entry leads to the existing configure form.
- [ ] Run the standalone container, open noVNC before clicking "Start Authentication" → welcome banner is visible (not a black screen).
- [ ] Open `http://<host>:8099`, click "Start Authentication", then switch to noVNC → Chromium opens for the Google login as before.
- [ ] Verify translations render correctly in EN / FR / HE.

https://claude.ai/code/session_01UZ47TjiaGkJr4RLCqjNeRo

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZ47TjiaGkJr4RLCqjNeRo)_