### PR TITLE
Fix bedtime switch and effective-today display (#113, #114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.2.7-rc2] - 2026-05-21
+
+### Fixed
+- **Bedtime switch now actually reaches the child device** — Same fix pattern as v1.2.7 for school time, applied to bedtime (#113). `switch.<child>_bedtime` and `familylink.enable_bedtime` / `familylink.disable_bedtime` now do both calls the Family Link web app sends when the user confirms "Apply changes to today as well?": (1) flip the weekly policy via `timeLimit:update`, (2) post a per-day override via `timeLimitOverrides:batchCreate` (action=2 to enable, action=1 to disable) using today's weekly bedtime hours and the matching `CAEQxx` day_code. The previous behavior only did step 1, which left tonight's slot unchanged on the device.
+- **Bedtime and school time switches now reflect the effective today state** — `is_on` for both switches now reads `bedtime_enabled_today` / `school_time_enabled_today` from `appliedTimeLimits`, which combines the weekly policy with daily overrides. Previously the switches only read the weekly revisions, so after a "today only" override the switch would snap back to its weekly value on the next coordinator refresh (~30-60s) and the user would think the toggle did nothing (#114).
+
+### Documentation
+- `GOOGLE_FAMILY_LINK_API_ANALYSIS.md` — added a "Bedtime daily override pattern" section, updated the endpoints table to flag the bedtime weekly-only toggle as misleading (same trap as school time), and added an "Apply bedtime today" entry documenting the reverse-engineered payload (uses `CAEQxx` day_code instead of school time's `[weekday, rule_uuid]` tuple).
+
+---
+
 ## [1.2.7] - 2026-05-16
 
 ### Fixed

--- a/GOOGLE_FAMILY_LINK_API_ANALYSIS.md
+++ b/GOOGLE_FAMILY_LINK_API_ANALYSIS.md
@@ -58,7 +58,8 @@
 | **Set bedtime schedule** | POST | `/kidsmanagement/v1/people/{childId}/timeLimitOverrides:batchCreate` | `[null, childId, [[null, null, 9, null, null, null, null, null, null, null, null, null, [2, [startH, startM], [endH, endM], day_code]]], [1]]` | Type 9 = set bedtime. Format: `[status, [startHour, startMin], [endHour, endMin], day_code]`. Status 2=enabled. |
 | **Apply school time today** (recommended, issue #111) | POST | `/kidsmanagement/v1/people/{childId}/timeLimitOverrides:batchCreate` | `[null, childId, [[null, null, 9, null, null, null, null, null, null, null, null, null, [action, [startH, startM], [endH, endM], null, [weekday, "579e5e01-...rule_uuid"]]]], [1]]` | Type 9 + schooltime rule reference at `[4]` (weekday 1-7, rule UUID). **action: 2=enable, 1=disable**. This is what the web app sends when the "Today" toggle is changed; it is the only call that actually locks/unlocks the device for the current day. Toggling the weekly policy alone (next row) is not enough — see issue #111. |
 | **Cancel time bonus / Remove school time override** | POST | `/kidsmanagement/v1/people/{childId}/timeLimitOverride/{overrideId}?$httpMethod=DELETE` | No body | Google API convention: POST with $httpMethod=DELETE. The web app calls this before creating an opposite-action school time override (so you don't end up with stacked overrides on the same day). |
-| **Enable/Disable bedtime** | PUT | `/kidsmanagement/v1/people/{childId}/timeLimit:update?$httpMethod=PUT` | `[null, childId, [[null, null, null, null], null, null, null, [null, [["487088e7-38b4-4f18-a5fb-4aab64ba9d2f", state]]]], null, [1]]` | UUID `487088e7-...` = bedtime policy.<br>state: 2=ON, 1=OFF |
+| **Apply bedtime today** (recommended, issue #113) | POST | `/kidsmanagement/v1/people/{childId}/timeLimitOverrides:batchCreate` | `[null, childId, [[null, null, 9, null, null, null, null, null, null, null, null, null, [action, [startH, startM], [endH, endM], "CAEQxx"]]], [1]]` | Type 9 + bedtime day_code at `[3]` (CAEQAQ=Mon … CAEQBw=Sun). **action: 2=enable, 1=disable**. Mirrors the "Ce soir seulement" / Tonight-only dialog in the web app. The bedtime override uses the day_code string instead of school time's `[weekday, rule_uuid]` tuple. |
+| **Toggle bedtime weekly policy** | PUT | `/kidsmanagement/v1/people/{childId}/timeLimit:update?$httpMethod=PUT` | `[null, childId, [[null, null, null, null], null, null, null, [null, [["487088e7-38b4-4f18-a5fb-4aab64ba9d2f", state]]]], null, [1]]` | UUID `487088e7-...` = bedtime policy.<br>state: 2=ON, 1=OFF. ⚠️ **Like school time, this only flips the weekly switch.** The bedtime slot already running tonight is not cancelled. The web app pairs this PUT with **Apply bedtime today** (above) when the user confirms "Apply changes to today as well?". |
 | **Toggle school time weekly policy** | PUT | `/kidsmanagement/v1/people/{childId}/timeLimit:update?$httpMethod=PUT` | `[null, childId, [[null, null, null, null], null, null, null, [null, [["579e5e01-8dfd-42f3-be6b-d77984842202", state]]]], null, [1]]` | UUID `579e5e01-...` = school time policy.<br>state: 2=ON, 1=OFF. ⚠️ **This only flips the weekly switch — it does NOT apply a change to the current day.** If today has no weekly slot, nothing happens on the child device. To actually lock/unlock today, use **Apply school time today** (above). |
 | **Enable/Disable daily limit** | PUT | `/kidsmanagement/v1/people/{childId}/timeLimit:update?$httpMethod=PUT` | `[null, childId, [null, [[state, null, null, null]]], null, [1]]` | state: 2=ON, 1=OFF |
 
@@ -72,6 +73,24 @@
 - **8**: SET daily limit duration (per device)
 - **9**: SET bedtime / school time schedule (per child)
 - **10**: ADD time bonus (per device)
+
+### Bedtime daily override pattern (issue #113)
+
+Bedtime suffers from the same desync problem school time had (#111): toggling the weekly switch alone does not always reach the child device, because the weekly slot already in progress can carry forward unchanged. The web app addresses this by always pairing the weekly PUT with a per-day override, just like school time but with a different reference encoding.
+
+**Difference vs. school time.** The override payload references the day with the opaque `CAEQxx` day_code (Monday=`CAEQAQ`, …, Sunday=`CAEQBw`), NOT a `[weekday_int, rule_uuid]` tuple. The type code is still `9`.
+
+**Toggle bedtime ON (web app):**
+1. `PUT /people/{childId}/timeLimit:update?$httpMethod=PUT` with `[null, childId, [[null,null,null,null], null,null,null, [null, [["487088e7-…bedtime_uuid", 2]]]], null, [1]]`
+2. `POST /people/{childId}/timeLimitOverrides:batchCreate` with `[null, childId, [[null,null,9, null,null,null,null,null,null,null,null,null, [2, [start_h,start_m], [end_h,end_m], "CAEQxx"]]], [1]]`
+
+Where `[start_h, …]` and `[end_h, …]` are today's weekly bedtime hours.
+
+**Toggle bedtime OFF (web app):** same as above but weekly state=1 and override action=1.
+
+**Single-day toggle ("Ce soir seulement" / Tonight only dialog):** only step 2 is sent; the weekly PUT is skipped. Picking action 1 or 2 controls whether tonight is suspended or active without changing the weekly policy.
+
+**No DELETE step.** The server treats overrides as keyed by day_code — posting a new override silently supersedes the previous one for the same day. (School time uses a different uniqueness key and the web app does emit DELETE there.)
 
 ### School time daily override pattern (issue #111)
 

--- a/custom_components/familylink/client/api.py
+++ b/custom_components/familylink/client/api.py
@@ -1115,6 +1115,10 @@ class FamilyLinkClient:
 				- schooltime_window: {start_ms, end_ms} or None
 				- bedtime_active: Boolean
 				- schooltime_active: Boolean
+			- bedtime_enabled_today: True if any device has an enabled bedtime
+				rule for the current weekday (combines weekly + daily overrides;
+				used by the bedtime switch for issue #114).
+			- schooltime_enabled_today: same for school time.
 		"""
 		if not self.is_authenticated():
 			raise AuthenticationError("Not authenticated")
@@ -1153,6 +1157,14 @@ class FamilyLinkClient:
 
 				device_lock_states = {}
 				devices = {}
+				# Today-effective flags computed from the per-device rule entries.
+				# Used by the switches to reflect the actual locked/unlocked state on
+				# the child device for today (issue #114) — combines weekly policy
+				# with any daily override that's been applied. See doc note in
+				# GOOGLE_FAMILY_LINK_API_ANALYSIS.md ("appliedTimeLimits effective
+				# state for today").
+				bedtime_enabled_today = False
+				schooltime_enabled_today = False
 
 				if len(data) > 1 and isinstance(data[1], list):
 					for device_data in data[1]:
@@ -1355,6 +1367,10 @@ class FamilyLinkClient:
 												if parse_as_bedtime:
 													device_info["bedtime_window"] = window_data
 													device_info["bedtime_active"] = window_active
+													# An enabled bedtime rule exists for today on this
+													# device — switch must show ON regardless of weekly
+													# revision (issue #114).
+													bedtime_enabled_today = True
 
 													_LOGGER.debug(
 														f"Device {device_id}: Bedtime window parsed - "
@@ -1364,6 +1380,7 @@ class FamilyLinkClient:
 												elif parse_as_schooltime:
 													device_info["schooltime_window"] = window_data
 													device_info["schooltime_active"] = window_active
+													schooltime_enabled_today = True
 
 													_LOGGER.debug(
 														f"Device {device_id}: Schooltime window parsed - "
@@ -1383,10 +1400,12 @@ class FamilyLinkClient:
 											if device_info["bedtime_window"] is None:
 												device_info["bedtime_window"] = {"start_ms": start_ms, "end_ms": end_ms}
 												device_info["bedtime_active"] = True
+												bedtime_enabled_today = True
 												_LOGGER.debug(f"Device {device_id}: bedtime window {start_ms}-{end_ms}")
 											elif device_info["schooltime_window"] is None:
 												device_info["schooltime_window"] = {"start_ms": start_ms, "end_ms": end_ms}
 												device_info["schooltime_active"] = True
+												schooltime_enabled_today = True
 												_LOGGER.debug(f"Device {device_id}: schooltime window {start_ms}-{end_ms}")
 									except (ValueError, TypeError):
 										pass
@@ -1438,7 +1457,13 @@ class FamilyLinkClient:
 
 				return {
 					"device_lock_states": device_lock_states,
-					"devices": devices
+					"devices": devices,
+					# Today-effective flags (issue #114): combine weekly policy
+					# with daily overrides so the HA switches show what Google
+					# actually applies on the child device right now, instead of
+					# only the weekly revision.
+					"bedtime_enabled_today": bedtime_enabled_today,
+					"schooltime_enabled_today": schooltime_enabled_today,
 				}
 
 		except SessionExpiredError:
@@ -1554,77 +1579,65 @@ class FamilyLinkClient:
 			_LOGGER.error(f"Unexpected error cancelling time bonus: {err}")
 			return False
 
+	# Day-of-week → CAEQ day_code used by Google's batchCreate payload for
+	# bedtime overrides. ISO weekday: 1=Monday … 7=Sunday.
+	_BEDTIME_DAY_CODES = {
+		1: "CAEQAQ",  # Monday
+		2: "CAEQAg",  # Tuesday
+		3: "CAEQAw",  # Wednesday
+		4: "CAEQBA",  # Thursday
+		5: "CAEQBQ",  # Friday
+		6: "CAEQBg",  # Saturday
+		7: "CAEQBw",  # Sunday
+	}
+
 	async def async_enable_bedtime(self, account_id: str | None = None, rule_id: str | None = None) -> bool:
-		"""Enable bedtime (downtime) restrictions for a child.
+		"""Enable bedtime, mirroring the Family Link web app (issue #113).
 
-		Args:
-			account_id: User ID of the supervised child (optional)
-			rule_id: Bedtime rule UUID (optional, fetched dynamically if not provided)
+		Posts both calls the web app sends when the user toggles bedtime on
+		and confirms "Apply changes to today as well?":
 
-		Returns:
-			True if successful, False otherwise
+		1. `PUT timeLimit:update` flips the weekly revision to state 2.
+		2. `POST timeLimitOverrides:batchCreate` posts a per-day override
+		   (action=2) with today's weekly bedtime hours, so the change takes
+		   effect on the child device for tonight without waiting for the
+		   weekly slot to start fresh.
+
+		Without step 2 the child device may not see the change until the
+		next weekly slot — that's exactly what issue #113 reported.
 		"""
-		if not self.is_authenticated():
-			raise AuthenticationError("Not authenticated")
-
-		if not account_id:
-			account_id = await self.async_get_supervised_child_id()
-
-		# Fetch rule_id dynamically if not provided
-		if not rule_id:
-			time_limit_data = await self.async_get_time_limit(account_id)
-			rule_id = time_limit_data.get("bedtime_rule_id")
-			if not rule_id:
-				_LOGGER.error("Could not find bedtime rule ID for this account")
-				return False
-
-		try:
-			session = await self._get_session()
-			cookie_header = self._get_cookie_header()
-
-			# Payload format: [null, account_id, [[null, null, null, null], null, null, null, [null, [[rule_id, 2]]]], null, [1]]
-			# Status 2 = enabled
-			payload = json.dumps([
-				None,
-				account_id,
-				[[None, None, None, None], None, None, None, [None, [[rule_id, 2]]]],
-				None,
-				[1]
-			])
-
-			url = f"{self.BASE_URL}/people/{account_id}/timeLimit:update"
-			_LOGGER.debug(f"Enabling bedtime for account {account_id} with rule_id {rule_id}")
-
-			async with session.put(
-				url,
-				headers={
-					"Content-Type": "application/json+protobuf",
-					"Cookie": cookie_header
-				},
-				data=payload,
-				params={"$httpMethod": "PUT"}
-			) as response:
-				if response.status != 200:
-					response_text = await response.text()
-					_LOGGER.error(f"Failed to enable bedtime {response.status}: {response_text}")
-					return False
-
-				_LOGGER.info(f"Successfully enabled bedtime for account {account_id}")
-				return True
-
-		except Exception as err:
-			_LOGGER.error(f"Unexpected error enabling bedtime: {err}")
-			return False
+		return await self._async_apply_bedtime_today(
+			enable=True, account_id=account_id, rule_id=rule_id
+		)
 
 	async def async_disable_bedtime(self, account_id: str | None = None, rule_id: str | None = None) -> bool:
-		"""Disable bedtime (downtime) restrictions for a child.
+		"""Disable bedtime, mirroring the Family Link web app (issue #113).
 
-		Args:
-			account_id: User ID of the supervised child (optional)
-			rule_id: Bedtime rule UUID (optional, fetched dynamically if not provided)
+		Posts both calls the web app sends when the user toggles bedtime
+		off and confirms "Apply changes to today as well?":
 
-		Returns:
-			True if successful, False otherwise
+		1. `PUT timeLimit:update` flips the weekly revision to state 1.
+		2. `POST timeLimitOverrides:batchCreate` posts a per-day override
+		   (action=1) so the bedtime slot already running tonight is
+		   actually suspended on the child device.
+		"""
+		return await self._async_apply_bedtime_today(
+			enable=False, account_id=account_id, rule_id=rule_id
+		)
+
+	async def _async_apply_bedtime_today(
+		self,
+		enable: bool,
+		account_id: str | None = None,
+		rule_id: str | None = None,
+	) -> bool:
+		"""Flip the weekly bedtime policy AND post a per-day override.
+
+		This combination is what the Family Link web app sends when the user
+		toggles the bedtime weekly switch and confirms "Apply changes to
+		today as well?". Doing only the weekly PUT (the previous behavior)
+		left the child device unaffected on days where the weekly schedule
+		and tonight's actual hours diverged — issue #113.
 		"""
 		if not self.is_authenticated():
 			raise AuthenticationError("Not authenticated")
@@ -1632,50 +1645,115 @@ class FamilyLinkClient:
 		if not account_id:
 			account_id = await self.async_get_supervised_child_id()
 
-		# Fetch rule_id dynamically if not provided
+		# Need the rule_id (always) AND today's bedtime hours (for the
+		# override payload). Fetch both via one call to async_get_time_limit.
+		time_limit_data = await self.async_get_time_limit(account_id)
 		if not rule_id:
-			time_limit_data = await self.async_get_time_limit(account_id)
 			rule_id = time_limit_data.get("bedtime_rule_id")
 			if not rule_id:
 				_LOGGER.error("Could not find bedtime rule ID for this account")
 				return False
 
+		# Pick the weekly bedtime slot matching today; fall back to a sane
+		# default (21:30 → 07:00) if the user has no slot configured for
+		# today — that way the override at least covers a reasonable window.
+		now_local = dt_util.now()
+		weekday = now_local.isoweekday()
+		day_code = self._BEDTIME_DAY_CODES.get(weekday)
+		if not day_code:
+			_LOGGER.error("Unexpected weekday %s — cannot build bedtime override", weekday)
+			return False
+
+		start, end = [21, 30], [7, 0]
+		for slot in time_limit_data.get("bedtime_schedule") or []:
+			if slot.get("day") == weekday:
+				slot_start = slot.get("start")
+				slot_end = slot.get("end")
+				if isinstance(slot_start, list) and len(slot_start) == 2:
+					start = slot_start
+				if isinstance(slot_end, list) and len(slot_end) == 2:
+					end = slot_end
+				break
+
 		try:
 			session = await self._get_session()
 			cookie_header = self._get_cookie_header()
 
-			# Payload format: [null, account_id, [[null, null, null, null], null, null, null, [null, [[rule_id, 1]]]], null, [1]]
-			# Status 1 = disabled
-			payload = json.dumps([
+			# Step 1: flip the weekly policy. The web app sends this even
+			# when the user only wants "tonight" because the dialog choice
+			# also persists the weekly state.
+			weekly_state = 2 if enable else 1
+			weekly_payload = json.dumps([
 				None,
 				account_id,
-				[[None, None, None, None], None, None, None, [None, [[rule_id, 1]]]],
+				[[None, None, None, None], None, None, None, [None, [[rule_id, weekly_state]]]],
 				None,
-				[1]
+				[1],
 			])
-
-			url = f"{self.BASE_URL}/people/{account_id}/timeLimit:update"
-			_LOGGER.debug(f"Disabling bedtime for account {account_id} with rule_id {rule_id}")
-
+			weekly_url = f"{self.BASE_URL}/people/{account_id}/timeLimit:update"
 			async with session.put(
-				url,
+				weekly_url,
 				headers={
 					"Content-Type": "application/json+protobuf",
-					"Cookie": cookie_header
+					"Cookie": cookie_header,
 				},
-				data=payload,
-				params={"$httpMethod": "PUT"}
+				data=weekly_payload,
+				params={"$httpMethod": "PUT"},
 			) as response:
 				if response.status != 200:
 					response_text = await response.text()
-					_LOGGER.error(f"Failed to disable bedtime {response.status}: {response_text}")
+					_LOGGER.error(
+						"Failed to update weekly bedtime policy (HTTP %s): %s",
+						response.status, response_text,
+					)
 					return False
 
-				_LOGGER.info(f"Successfully disabled bedtime for account {account_id}")
-				return True
+			# Step 2: post the per-day override. Bedtime overrides reference
+			# the day via the opaque CAEQxx day_code (NOT a [weekday, uuid]
+			# tuple like schooltime — see GOOGLE_FAMILY_LINK_API_ANALYSIS.md).
+			action = 2 if enable else 1
+			override_payload = json.dumps([
+				None,
+				account_id,
+				[[
+					None, None,
+					9,
+					None, None, None, None, None, None, None, None, None,
+					[action, start, end, day_code],
+				]],
+				[1],
+			])
+			override_url = f"{self.BASE_URL}/people/{account_id}/timeLimitOverrides:batchCreate"
+			_LOGGER.debug(
+				"Applying bedtime override action=%s window=%s-%s day_code=%s rule=%s",
+				action, start, end, day_code, rule_id,
+			)
+			async with session.post(
+				override_url,
+				headers={
+					"Content-Type": "application/json+protobuf",
+					"Cookie": cookie_header,
+				},
+				data=override_payload,
+			) as response:
+				if response.status != 200:
+					response_text = await response.text()
+					_LOGGER.error(
+						"Bedtime weekly policy was updated but the daily override failed "
+						"(HTTP %s): %s — tonight may not reflect the change",
+						response.status, response_text,
+					)
+					return False
+
+			_LOGGER.info(
+				"Successfully %s bedtime for account %s (weekly + tonight %02d:%02d-%02d:%02d)",
+				"enabled" if enable else "disabled",
+				account_id, start[0], start[1], end[0], end[1],
+			)
+			return True
 
 		except Exception as err:
-			_LOGGER.error(f"Unexpected error disabling bedtime: {err}")
+			_LOGGER.error("Unexpected error applying bedtime override: %s", err)
 			return False
 
 	async def async_enable_school_time(self, account_id: str | None = None, rule_id: str | None = None) -> bool:

--- a/custom_components/familylink/coordinator.py
+++ b/custom_components/familylink/coordinator.py
@@ -198,15 +198,24 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 			# Fetch applied time limits (lock states and per-device time data)
 			device_lock_states = {}
 			devices_time_data = {}
+			# Today-effective flags from appliedTimeLimits — combine the weekly
+			# policy with any daily override that's been posted. The switches
+			# read these instead of the weekly revisions so they reflect what
+			# Google actually applies on the child device right now (issue #114).
+			bedtime_enabled_today = None
+			schooltime_enabled_today = None
 
 			try:
 				applied_limits_data = await self.client.async_get_applied_time_limits(account_id=child_id)
 				device_lock_states = applied_limits_data.get("device_lock_states", {})
 				devices_time_data = applied_limits_data.get("devices", {})
+				bedtime_enabled_today = applied_limits_data.get("bedtime_enabled_today")
+				schooltime_enabled_today = applied_limits_data.get("schooltime_enabled_today")
 				_LOGGER.debug(
 					f"Fetched applied time limits for {child_name}: "
 					f"{len(device_lock_states)} device lock states, "
-					f"{len(devices_time_data)} devices with time data"
+					f"{len(devices_time_data)} devices with time data, "
+					f"bedtime_today={bedtime_enabled_today}, schooltime_today={schooltime_enabled_today}"
 				)
 			except SessionExpiredError:
 				raise  # Re-raise to trigger auth notification
@@ -313,6 +322,12 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 				"app_usage_sessions": apps_usage_data.get("appUsageSessions", []) if apps_usage_data else [],
 				"bedtime_enabled": bedtime_enabled,
 				"school_time_enabled": school_time_enabled,
+				# Effective state for today (issue #114) — read from
+				# appliedTimeLimits, which already merges weekly policy with
+				# daily overrides. The switches use these instead of the
+				# weekly-only revisions above.
+				"bedtime_enabled_today": bedtime_enabled_today,
+				"school_time_enabled_today": schooltime_enabled_today,
 				"bedtime_schedule": bedtime_schedule,
 				"school_time_schedule": school_time_schedule,
 				"daily_limit_enabled": daily_limit_enabled,

--- a/custom_components/familylink/manifest.json
+++ b/custom_components/familylink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "familylink",
   "name": "Google Family Link",
-  "version": "1.2.7-rc1",
+  "version": "1.2.7-rc2",
   "documentation": "https://github.com/noiwid/HAFamilyLink",
   "issue_tracker": "https://github.com/noiwid/HAFamilyLink/issues",
   "codeowners": [

--- a/custom_components/familylink/switch.py
+++ b/custom_components/familylink/switch.py
@@ -292,20 +292,27 @@ class FamilyLinkBedtimeSwitch(CoordinatorEntity, SwitchEntity):
 
 	@property
 	def is_on(self) -> bool:
-		"""Return True if bedtime is enabled."""
+		"""Return True if bedtime is enabled for today.
+
+		Reads the effective state from appliedTimeLimits rather than the
+		weekly revision, so that daily overrides (issue #114) are honored.
+		Falls back to the weekly revision if the today-effective field is
+		not populated (e.g. first refresh before appliedTimeLimits returns).
+		"""
 		# Check for pending state first (takes precedence for 5 seconds after change)
 		pending_state = self.coordinator.get_pending_time_limit_state(self._child_id, "bedtime")
 		if pending_state is not None:
 			return pending_state
 
-		# Otherwise use actual state from API
 		if self.coordinator.data and "children_data" in self.coordinator.data:
 			for child_data in self.coordinator.data["children_data"]:
 				if child_data["child_id"] == self._child_id:
-					bedtime_state = child_data.get("bedtime_enabled")
-					if bedtime_state is not None:
-						return bedtime_state
-		# Default to False if unknown
+					today = child_data.get("bedtime_enabled_today")
+					if today is not None:
+						return today
+					weekly = child_data.get("bedtime_enabled")
+					if weekly is not None:
+						return weekly
 		return False
 
 	@property
@@ -391,20 +398,27 @@ class FamilyLinkSchoolTimeSwitch(CoordinatorEntity, SwitchEntity):
 
 	@property
 	def is_on(self) -> bool:
-		"""Return True if school time is enabled."""
+		"""Return True if school time is enabled for today.
+
+		Reads the effective state from appliedTimeLimits rather than the
+		weekly revision, so that daily overrides (issue #114) are honored.
+		Falls back to the weekly revision if the today-effective field is
+		not populated.
+		"""
 		# Check for pending state first (takes precedence for 5 seconds after change)
 		pending_state = self.coordinator.get_pending_time_limit_state(self._child_id, "school_time")
 		if pending_state is not None:
 			return pending_state
 
-		# Otherwise use actual state from API
 		if self.coordinator.data and "children_data" in self.coordinator.data:
 			for child_data in self.coordinator.data["children_data"]:
 				if child_data["child_id"] == self._child_id:
-					school_time_state = child_data.get("school_time_enabled")
-					if school_time_state is not None:
-						return school_time_state
-		# Default to False if unknown
+					today = child_data.get("school_time_enabled_today")
+					if today is not None:
+						return today
+					weekly = child_data.get("school_time_enabled")
+					if weekly is not None:
+						return weekly
 		return False
 
 	@property


### PR DESCRIPTION
#113 — async_enable_bedtime / async_disable_bedtime and the matching services only flipped the weekly policy via timeLimit:update. The same trap as school time before v1.2.7: tonight's slot, if already running, stays on the child device. Now both calls the official web app sends when the user confirms "Apply changes to today as well?" are emitted: PUT timeLimit:update + POST timeLimitOverrides:batchCreate with today's weekly bedtime hours and the matching CAEQxx day_code. Bedtime overrides use the day_code string at index 3 of the payload, not the [weekday, rule_uuid] tuple school time uses — verified by capturing the web app traffic.

#114 — FamilyLinkBedtimeSwitch.is_on and FamilyLinkSchoolTimeSwitch.is_on read bedtime_enabled / school_time_enabled, which come from the weekly revisions. After a "today only" override the switches snapped back to the weekly value on the next coordinator refresh. Now is_on reads bedtime_enabled_today / school_time_enabled_today, computed from appliedTimeLimits which already merges weekly policy with daily overrides. Falls back to the weekly value if today-effective is unpopulated (first refresh).

Bumps to 1.2.7-rc2.