### PR TITLE
Fix bedtime schedule parsing — wrong array indices (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.2.7-rc3] - 2026-05-26
+
+### Fixed
+- **Bedtime override now uses today's actual schedule instead of hardcoded 21:30–07:00** — The CAEQ (bedtime) and CAMQ (school time) schedule parsers read start/end from the wrong array indices, skipping the `stateFlag` at index 2. Start was read as the stateFlag integer (always failing the `isinstance(list)` check) and end was read as the actual start time. Both fell through to the hardcoded defaults `[21, 30]→[7, 0]`. Fixed to read `item[3]` (start) and `item[4]` (end), matching the documented protobuf layout (#113)
+
+---
+
 ## [1.2.7-rc2] - 2026-05-21
 
 ### Fixed

--- a/custom_components/familylink/client/api.py
+++ b/custom_components/familylink/client/api.py
@@ -1664,8 +1664,14 @@ class FamilyLinkClient:
 			_LOGGER.error("Unexpected weekday %s — cannot build bedtime override", weekday)
 			return False
 
+		bedtime_schedule = time_limit_data.get("bedtime_schedule") or []
+		_LOGGER.debug(
+			"Bedtime schedule has %d entries (looking for weekday %d): %s",
+			len(bedtime_schedule), weekday, bedtime_schedule,
+		)
+
 		start, end = [21, 30], [7, 0]
-		for slot in time_limit_data.get("bedtime_schedule") or []:
+		for slot in bedtime_schedule:
 			if slot.get("day") == weekday:
 				slot_start = slot.get("start")
 				slot_end = slot.get("end")
@@ -1673,7 +1679,13 @@ class FamilyLinkClient:
 					start = slot_start
 				if isinstance(slot_end, list) and len(slot_end) == 2:
 					end = slot_end
+				_LOGGER.debug("Using schedule slot for weekday %d: %s-%s", weekday, start, end)
 				break
+		else:
+			_LOGGER.warning(
+				"No bedtime schedule found for weekday %d, using default %s-%s",
+				weekday, start, end,
+			)
 
 		try:
 			session = await self._get_session()
@@ -2352,10 +2364,12 @@ class FamilyLinkClient:
 									for item in schedule_list:
 										if isinstance(item, list) and len(item) >= 4:
 											if isinstance(item[0], str) and item[0].startswith("CAEQ"):
+												# CAEQ format: [code, day, stateFlag, [startH,startM], [endH,endM], ...]
+												# item[2] is stateFlag (2=ON, 1=OFF), NOT the start time.
 												day = item[1] if len(item) > 1 else None
-												start = item[2] if len(item) > 2 else None
-												end = item[3] if len(item) > 3 else None
-												if day and start and end:
+												start = item[3] if len(item) > 3 else None
+												end = item[4] if len(item) > 4 else None
+												if day and isinstance(start, list) and isinstance(end, list):
 													bedtime_schedule.append({
 														"day": day,
 														"start": start,  # [hh, mm]
@@ -2374,10 +2388,12 @@ class FamilyLinkClient:
 							for item in config_data[2]:
 								if isinstance(item, list) and len(item) >= 4:
 									if isinstance(item[0], str) and item[0].startswith("CAMQ"):
+										# CAMQ format: [code, day, stateFlag, [startH,startM], [endH,endM], ...]
+										# item[2] is stateFlag (2=ON, 1=OFF), NOT the start time.
 										day = item[1] if len(item) > 1 else None
-										start = item[2] if len(item) > 2 else None
-										end = item[3] if len(item) > 3 else None
-										if day and start and end:
+										start = item[3] if len(item) > 3 else None
+										end = item[4] if len(item) > 4 else None
+										if day and isinstance(start, list) and isinstance(end, list):
 											school_time_schedule.append({
 												"day": day,
 												"start": start,

--- a/custom_components/familylink/manifest.json
+++ b/custom_components/familylink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "familylink",
   "name": "Google Family Link",
-  "version": "1.2.7-rc2",
+  "version": "1.2.7-rc3",
   "documentation": "https://github.com/noiwid/HAFamilyLink",
   "issue_tracker": "https://github.com/noiwid/HAFamilyLink/issues",
   "codeowners": [


### PR DESCRIPTION
## Summary

Fixes the remaining issue reported by @maikel-ha in #113: enabling bedtime via HA always sets "Only tonight" to **21:30–07:00** instead of today's configured bedtime hours.

**Root cause:** The CAEQ (bedtime) and CAMQ (school time) schedule parsers in `async_get_time_limit` read `item[2]` as start and `item[3]` as end, but the actual protobuf layout is:

```
[CAEQ_code, day, stateFlag, [startH,startM], [endH,endM], ...]
```

`item[2]` is the stateFlag integer (2=ON, 1=OFF), **not** the start time. This caused:

1. `slot["start"]` = `2` (int) → `isinstance(2, list)` fails → fallback to default `[21, 30]`
2. `slot["end"]` = `[startH, startM]` (the real start) → wrong value or also falls through
3. Both stay at hardcoded defaults `[21, 30]` → `[7, 0]`

## Changes

- `client/api.py` — CAEQ parser: read `item[3]` for start, `item[4]` for end (skip stateFlag at `[2]`). Added `isinstance(list)` validation on the parsed values.
- `client/api.py` — CAMQ parser: same index fix (prevents future bugs if school_time schedule is used).
- `client/api.py` — `_async_apply_bedtime_today`: added debug log of parsed schedule entries and a warning when no slot matches today (falls through to defaults).
- Bumped version to `1.2.7-rc3`.

## Test plan

- [ ] Enable bedtime via HA with a custom schedule (e.g. 00:00–23:59) → "Only tonight" in the Family Link app should show the user's actual hours, not 21:30–07:00.
- [ ] Toggle bedtime on/off during an active bedtime slot → device reacts correctly with the right hours.
- [ ] Check HA logs at debug level: "Using schedule slot for weekday X" should appear with the correct hours.
