### PR TITLE
fix: cache last known data on transient API errors (503/500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.2.7-rc5] - 2026-06-09
+
+### Added
+- **Cache last known data on transient API errors (503/500/timeouts)** — Google's Family Link API (especially `appsandusage`) regularly returns transient 5xx errors, which previously dropped every sensor to `unavailable` even though the underlying data was unchanged. The coordinator now keeps the last successful fetch in memory and returns it on transient errors, with per-child fallbacks for each endpoint (apps/usage, time limit config, applied limits, screen time). `SessionExpiredError` still propagates so re-authentication is unaffected; the cache is cleared on restart. Thanks to @Naumsede for the contribution (#117).
+
+---
+
 ## [1.2.7-rc4] - 2026-06-09
 
 ### Fixed

--- a/custom_components/familylink/coordinator.py
+++ b/custom_components/familylink/coordinator.py
@@ -35,6 +35,7 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 		self._auth_notification_sent = False  # Only send auth notification once
 		self._pending_lock_states: dict[str, tuple[bool, float]] = {}  # device_id -> (locked, timestamp)
 		self._pending_time_limit_states: dict[str, dict[str, tuple[bool, float]]] = {}  # child_id -> {"bedtime": (enabled, timestamp), "school_time": (enabled, timestamp), "daily_limit": (enabled, timestamp)}
+		self._last_known_data: dict[str, Any] | None = None  # Cache for last successful fetch
 
 		# Get settings from options (runtime changes) or fall back to data (initial config)
 		self._location_tracking_enabled = entry.options.get(
@@ -62,6 +63,7 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 			if self._auth_notification_sent:
 				self._auth_notification_sent = False
 				_LOGGER.debug("Auth notification flag reset after successful data fetch")
+			self._last_known_data = result  # Store successful result
 			return result
 
 		except SessionExpiredError as err:
@@ -81,6 +83,7 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 				_LOGGER.info("Retrying data fetch after authentication refresh...")
 				result = await self._async_fetch_data()
 				self._is_retrying_auth = False  # Reset flag on success
+				self._last_known_data = result  # Store successful result
 				return result
 
 			except SessionExpiredError:
@@ -96,10 +99,16 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 
 		except FamilyLinkException as err:
 			_LOGGER.error("Error fetching Family Link data: %s", err)
+			if self._last_known_data is not None:
+				_LOGGER.warning("Returning last known data due to FamilyLinkException: %s", err)
+				return self._last_known_data
 			raise UpdateFailed(f"Error communicating with Family Link: {err}") from err
 
 		except Exception as err:
 			_LOGGER.exception("Unexpected error fetching Family Link data")
+			if self._last_known_data is not None:
+				_LOGGER.warning("Returning last known data due to unexpected error: %s", err)
+				return self._last_known_data
 			raise UpdateFailed(f"Unexpected error: {err}") from err
 
 	async def _async_fetch_data(self) -> dict[str, Any]:
@@ -157,6 +166,17 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 				raise  # Re-raise to trigger auth notification
 			except Exception as err:
 				_LOGGER.warning(f"Failed to fetch apps and usage data for {child_name}: {err}")
+				# Try to recover apps_usage_data from last known data cache
+				if self._last_known_data:
+					for cached_child in self._last_known_data.get("children_data", []):
+						if cached_child.get("child_id") == child_id:
+							apps_usage_data = {
+								"apps": cached_child.get("apps", []),
+								"deviceInfo": [],
+								"appUsageSessions": cached_child.get("app_usage_sessions", []),
+							}
+							_LOGGER.info(f"Using cached apps/usage data for {child_name}")
+							break
 
 			# Extract devices from apps_usage_data
 			devices = []
@@ -194,33 +214,41 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 				raise  # Re-raise to trigger auth notification
 			except Exception as err:
 				_LOGGER.warning(f"Failed to fetch time limit config for {child_name}: {err}")
+				# Try to recover from last known data cache
+				if self._last_known_data:
+					for cached_child in self._last_known_data.get("children_data", []):
+						if cached_child.get("child_id") == child_id:
+							bedtime_enabled = cached_child.get("bedtime_enabled")
+							school_time_enabled = cached_child.get("school_time_enabled")
+							bedtime_schedule = cached_child.get("bedtime_schedule")
+							school_time_schedule = cached_child.get("school_time_schedule")
+							_LOGGER.info(f"Using cached time limit config for {child_name}")
+							break
 
 			# Fetch applied time limits (lock states and per-device time data)
 			device_lock_states = {}
 			devices_time_data = {}
-			# Today-effective flags from appliedTimeLimits — combine the weekly
-			# policy with any daily override that's been posted. The switches
-			# read these instead of the weekly revisions so they reflect what
-			# Google actually applies on the child device right now (issue #114).
-			bedtime_enabled_today = None
-			schooltime_enabled_today = None
 
 			try:
 				applied_limits_data = await self.client.async_get_applied_time_limits(account_id=child_id)
 				device_lock_states = applied_limits_data.get("device_lock_states", {})
 				devices_time_data = applied_limits_data.get("devices", {})
-				bedtime_enabled_today = applied_limits_data.get("bedtime_enabled_today")
-				schooltime_enabled_today = applied_limits_data.get("schooltime_enabled_today")
 				_LOGGER.debug(
 					f"Fetched applied time limits for {child_name}: "
 					f"{len(device_lock_states)} device lock states, "
-					f"{len(devices_time_data)} devices with time data, "
-					f"bedtime_today={bedtime_enabled_today}, schooltime_today={schooltime_enabled_today}"
+					f"{len(devices_time_data)} devices with time data"
 				)
 			except SessionExpiredError:
 				raise  # Re-raise to trigger auth notification
 			except Exception as err:
 				_LOGGER.warning(f"Failed to fetch applied time limits for {child_name}: {err}")
+				# Try to recover from last known data cache
+				if self._last_known_data:
+					for cached_child in self._last_known_data.get("children_data", []):
+						if cached_child.get("child_id") == child_id:
+							devices_time_data = cached_child.get("devices_time_data", {})
+							_LOGGER.info(f"Using cached applied time limits for {child_name}")
+							break
 
 			# Update device cache with real lock states from API
 			import time
@@ -284,6 +312,14 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 				raise  # Re-raise to trigger auth notification
 			except Exception as err:
 				_LOGGER.warning(f"Failed to fetch screen time data for {child_name}: {err}")
+				# Try to recover from last known data cache
+				if self._last_known_data:
+					for cached_child in self._last_known_data.get("children_data", []):
+						if cached_child.get("child_id") == child_id:
+							screen_time = cached_child.get("screen_time")
+							if screen_time:
+								_LOGGER.info(f"Using cached screen time for {child_name}")
+							break
 
 			# Fetch location data for this child (if enabled)
 			location = None
@@ -322,12 +358,6 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 				"app_usage_sessions": apps_usage_data.get("appUsageSessions", []) if apps_usage_data else [],
 				"bedtime_enabled": bedtime_enabled,
 				"school_time_enabled": school_time_enabled,
-				# Effective state for today (issue #114) — read from
-				# appliedTimeLimits, which already merges weekly policy with
-				# daily overrides. The switches use these instead of the
-				# weekly-only revisions above.
-				"bedtime_enabled_today": bedtime_enabled_today,
-				"school_time_enabled_today": schooltime_enabled_today,
 				"bedtime_schedule": bedtime_schedule,
 				"school_time_schedule": school_time_schedule,
 				"daily_limit_enabled": daily_limit_enabled,

--- a/custom_components/familylink/coordinator.py
+++ b/custom_components/familylink/coordinator.py
@@ -100,14 +100,14 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 		except FamilyLinkException as err:
 			_LOGGER.error("Error fetching Family Link data: %s", err)
 			if self._last_known_data is not None:
-				_LOGGER.warning("Returning last known data due to FamilyLinkException: %s", err)
+				_LOGGER.info("Returning last known data due to FamilyLinkException: %s", err)
 				return self._last_known_data
 			raise UpdateFailed(f"Error communicating with Family Link: {err}") from err
 
 		except Exception as err:
 			_LOGGER.exception("Unexpected error fetching Family Link data")
 			if self._last_known_data is not None:
-				_LOGGER.warning("Returning last known data due to unexpected error: %s", err)
+				_LOGGER.info("Returning last known data due to unexpected error: %s", err)
 				return self._last_known_data
 			raise UpdateFailed(f"Unexpected error: {err}") from err
 
@@ -155,6 +155,7 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 
 			# Fetch complete apps and usage data for this child
 			apps_usage_data = None
+			cached_devices = None  # Populated from cache only if the fetch fails
 			try:
 				apps_usage_data = await self.client.async_get_apps_and_usage(account_id=child_id)
 				_LOGGER.debug(
@@ -166,7 +167,12 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 				raise  # Re-raise to trigger auth notification
 			except Exception as err:
 				_LOGGER.warning(f"Failed to fetch apps and usage data for {child_name}: {err}")
-				# Try to recover apps_usage_data from last known data cache
+				# Try to recover apps_usage_data from last known data cache.
+				# Note: deviceInfo is intentionally left out here — the cached
+				# child stores already-parsed `devices`, not raw deviceInfo, so
+				# we restore the device list directly below (cached_devices)
+				# rather than re-deriving it from an empty deviceInfo (which
+				# would otherwise wipe every device on a transient 503).
 				if self._last_known_data:
 					for cached_child in self._last_known_data.get("children_data", []):
 						if cached_child.get("child_id") == child_id:
@@ -175,7 +181,8 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 								"deviceInfo": [],
 								"appUsageSessions": cached_child.get("app_usage_sessions", []),
 							}
-							_LOGGER.info(f"Using cached apps/usage data for {child_name}")
+							cached_devices = cached_child.get("devices")
+							_LOGGER.debug(f"Using cached apps/usage data for {child_name}")
 							break
 
 			# Extract devices from apps_usage_data
@@ -193,6 +200,13 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 						"child_name": child_name,
 					}
 					devices.append(device)
+
+			# If the apps/usage fetch failed, deviceInfo is empty, so the loop
+			# above produced no devices. Fall back to the cached device list so
+			# a transient error doesn't make every device disappear.
+			if not devices and cached_devices:
+				devices = [dict(device) for device in cached_devices]
+				_LOGGER.debug(f"Restored {len(devices)} cached device(s) for {child_name}")
 
 			# Fetch time limit configuration (bedtime/school time schedules and enabled states)
 			bedtime_enabled = None
@@ -222,21 +236,30 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 							school_time_enabled = cached_child.get("school_time_enabled")
 							bedtime_schedule = cached_child.get("bedtime_schedule")
 							school_time_schedule = cached_child.get("school_time_schedule")
-							_LOGGER.info(f"Using cached time limit config for {child_name}")
+							_LOGGER.debug(f"Using cached time limit config for {child_name}")
 							break
 
 			# Fetch applied time limits (lock states and per-device time data)
 			device_lock_states = {}
 			devices_time_data = {}
+			# Today-effective flags from appliedTimeLimits — combine the weekly
+			# policy with any daily override that's been posted. The switches
+			# read these instead of the weekly revisions so they reflect what
+			# Google actually applies on the child device right now (issue #114).
+			bedtime_enabled_today = None
+			schooltime_enabled_today = None
 
 			try:
 				applied_limits_data = await self.client.async_get_applied_time_limits(account_id=child_id)
 				device_lock_states = applied_limits_data.get("device_lock_states", {})
 				devices_time_data = applied_limits_data.get("devices", {})
+				bedtime_enabled_today = applied_limits_data.get("bedtime_enabled_today")
+				schooltime_enabled_today = applied_limits_data.get("schooltime_enabled_today")
 				_LOGGER.debug(
 					f"Fetched applied time limits for {child_name}: "
 					f"{len(device_lock_states)} device lock states, "
-					f"{len(devices_time_data)} devices with time data"
+					f"{len(devices_time_data)} devices with time data, "
+					f"bedtime_today={bedtime_enabled_today}, schooltime_today={schooltime_enabled_today}"
 				)
 			except SessionExpiredError:
 				raise  # Re-raise to trigger auth notification
@@ -247,7 +270,9 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 					for cached_child in self._last_known_data.get("children_data", []):
 						if cached_child.get("child_id") == child_id:
 							devices_time_data = cached_child.get("devices_time_data", {})
-							_LOGGER.info(f"Using cached applied time limits for {child_name}")
+							bedtime_enabled_today = cached_child.get("bedtime_enabled_today")
+							schooltime_enabled_today = cached_child.get("school_time_enabled_today")
+							_LOGGER.debug(f"Using cached applied time limits for {child_name}")
 							break
 
 			# Update device cache with real lock states from API
@@ -318,7 +343,7 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 						if cached_child.get("child_id") == child_id:
 							screen_time = cached_child.get("screen_time")
 							if screen_time:
-								_LOGGER.info(f"Using cached screen time for {child_name}")
+								_LOGGER.debug(f"Using cached screen time for {child_name}")
 							break
 
 			# Fetch location data for this child (if enabled)
@@ -358,6 +383,12 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 				"app_usage_sessions": apps_usage_data.get("appUsageSessions", []) if apps_usage_data else [],
 				"bedtime_enabled": bedtime_enabled,
 				"school_time_enabled": school_time_enabled,
+				# Effective state for today (issue #114) — read from
+				# appliedTimeLimits, which already merges weekly policy with
+				# daily overrides. The switches use these instead of the
+				# weekly-only revisions above.
+				"bedtime_enabled_today": bedtime_enabled_today,
+				"school_time_enabled_today": schooltime_enabled_today,
 				"bedtime_schedule": bedtime_schedule,
 				"school_time_schedule": school_time_schedule,
 				"daily_limit_enabled": daily_limit_enabled,

--- a/custom_components/familylink/manifest.json
+++ b/custom_components/familylink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "familylink",
   "name": "Google Family Link",
-  "version": "1.2.7-rc4",
+  "version": "1.2.7-rc5",
   "documentation": "https://github.com/noiwid/HAFamilyLink",
   "issue_tracker": "https://github.com/noiwid/HAFamilyLink/issues",
   "codeowners": [


### PR DESCRIPTION
## Problem
Google's Family Link API regularly returns HTTP 503/500 errors, especially  for the `appsandusage` endpoint. This causes all sensors (Top Apps, screen  time, etc.) to immediately become `unavailable` in Home Assistant, even  though the underlying data hasn't actually changed.

## Solution
Add a `_last_known_data` cache to the coordinator. On transient errors  (503, 500, network timeouts), the last successful fetch is returned instead  of raising `UpdateFailed`. This keeps sensors at their last known values  until a successful fetch occurs.

- `SessionExpiredError` still propagates correctly (auth errors are not cached)
- Per-child fallback in `_async_fetch_data` for granular recovery
- Cache is in-memory only, resets on HA restart

## Tested with
HA 2026.x, integration v1.2.5, repeated 503 errors from Google API