### PR TITLE
Add "ring device" action and per-device Ring button

### DIFF
--- a/custom_components/familylink/__init__.py
+++ b/custom_components/familylink/__init__.py
@@ -27,6 +27,7 @@ from .const import (
 	SERVICE_SET_BEDTIME,
 	SERVICE_SET_DAILY_LIMIT,
 	SERVICE_REFRESH_LOCATION,
+	SERVICE_RING_DEVICE,
 	SERVICE_UNBLOCK_ALL_APPS,
 	SERVICE_UNBLOCK_APP,
 )
@@ -123,6 +124,12 @@ SCHEMA_SET_BEDTIME = vol.Schema({
 
 SCHEMA_REFRESH_LOCATION = vol.Schema({
 	vol.Optional("entity_id"): cv.entity_id,
+	vol.Optional("child_id"): cv.string,
+})
+
+SCHEMA_RING_DEVICE = vol.Schema({
+	vol.Optional("entity_id"): cv.entity_id,
+	vol.Optional("device_id"): cv.string,
 	vol.Optional("child_id"): cv.string,
 })
 
@@ -744,6 +751,37 @@ async def async_setup_services(hass: HomeAssistant, coordinator: FamilyLinkDataU
 		schema=SCHEMA_SET_APP_DAILY_LIMIT,
 	)
 
+	async def handle_ring_device(call: ServiceCall) -> None:
+		"""Handle ring_device service call - make the device sound."""
+		_require_client()
+		entity_id = call.data.get("entity_id")
+		device_id = call.data.get("device_id")
+		child_id = call.data.get("child_id")
+
+		# If entity_id provided, extract IDs from entity attributes
+		if entity_id:
+			extracted_device_id, extracted_child_id = extract_ids_from_entity(hass, entity_id, require_device_id=True)
+			device_id = device_id or extracted_device_id
+			child_id = child_id or extracted_child_id
+
+		if not device_id:
+			raise ValueError("device_id is required. Either select an entity or provide device_id manually.")
+
+		_LOGGER.info(f"Service called: ring_device for device {device_id}")
+
+		try:
+			success = await coordinator.client.async_ring_device(
+				device_id=device_id,
+				child_id=child_id,
+			)
+			if success:
+				_LOGGER.info(f"Successfully rang device {device_id}")
+			else:
+				_LOGGER.error(f"Failed to ring device {device_id}")
+		except Exception as err:
+			_LOGGER.error(f"Error ringing device: {err}")
+			raise
+
 	# Register time management services
 	hass.services.async_register(
 		DOMAIN,
@@ -813,6 +851,13 @@ async def async_setup_services(hass: HomeAssistant, coordinator: FamilyLinkDataU
 		SERVICE_REFRESH_LOCATION,
 		handle_refresh_location,
 		schema=SCHEMA_REFRESH_LOCATION,
+	)
+
+	hass.services.async_register(
+		DOMAIN,
+		SERVICE_RING_DEVICE,
+		handle_ring_device,
+		schema=SCHEMA_RING_DEVICE,
 	)
 
 	_LOGGER.debug("Family Link services registered")

--- a/custom_components/familylink/button.py
+++ b/custom_components/familylink/button.py
@@ -63,6 +63,8 @@ async def async_setup_entry(
 			entities.append(FamilyLinkTimeBonusButton(coordinator, device, child_id, child_name, 30))
 			entities.append(FamilyLinkTimeBonusButton(coordinator, device, child_id, child_name, 60))
 			entities.append(CancelTimeBonusButton(coordinator, device, child_id, child_name))
+			# Ring button (make the device sound to help locate it)
+			entities.append(RingDeviceButton(coordinator, device, child_id, child_name))
 
 	_LOGGER.debug(f"Created {len(entities)} time bonus button entities")
 	async_add_entities(entities, update_before_add=True)
@@ -237,3 +239,65 @@ class CancelTimeBonusButton(CoordinatorEntity, ButtonEntity):
 			)
 			# Refresh to update sensors
 			await self.coordinator.async_request_refresh()
+
+
+class RingDeviceButton(CoordinatorEntity, ButtonEntity):
+	"""Button to ring a Family Link device (make it sound to help locate it)."""
+
+	def __init__(
+		self,
+		coordinator: FamilyLinkDataUpdateCoordinator,
+		device: dict[str, Any],
+		child_id: str,
+		child_name: str,
+	) -> None:
+		"""Initialize the button."""
+		super().__init__(coordinator)
+
+		self._device_id = device["id"]
+		self._device_name = device["name"]
+		self._child_id = child_id
+		self._child_name = child_name
+
+		self._attr_name = f"{device['name']} Ring"
+		self._attr_unique_id = f"{DOMAIN}_{child_id}_{device['id']}_ring"
+
+	@property
+	def device_info(self) -> DeviceInfo:
+		"""Return device information."""
+		return DeviceInfo(
+			identifiers={(DOMAIN, f"{self._child_id}_{self._device_id}")},
+			name=self._device_name,
+			manufacturer="Google",
+			model="Family Link Device",
+		)
+
+	@property
+	def icon(self) -> str:
+		"""Return the icon for the button."""
+		return "mdi:bell-ring"
+
+	@property
+	def available(self) -> bool:
+		"""Return True if entity is available."""
+		return self.coordinator.last_update_success
+
+	async def async_press(self) -> None:
+		"""Handle the button press - ring the device."""
+		if self.coordinator.client is None:
+			_LOGGER.error("Cannot ring device: client not connected")
+			return
+
+		_LOGGER.info(
+			f"Ringing device {self._device_name} for {self._child_name}"
+		)
+
+		success = await self.coordinator.client.async_ring_device(
+			device_id=self._device_id,
+			child_id=self._child_id,
+		)
+
+		if not success:
+			_LOGGER.error(f"Failed to ring device {self._device_name}")
+		else:
+			_LOGGER.info(f"Successfully rang device {self._device_name}")

--- a/custom_components/familylink/client/api.py
+++ b/custom_components/familylink/client/api.py
@@ -18,6 +18,7 @@ from homeassistant.util import dt as dt_util
 from ..auth.addon_client import AddonCookieClient
 from ..const import (
 	DEVICE_LOCK_ACTION,
+	DEVICE_RING_ACTION_CODE,
 	DEVICE_UNLOCK_ACTION,
 	LOGGER_NAME,
 )
@@ -1073,6 +1074,71 @@ class FamilyLinkClient:
 		except Exception as err:
 			_LOGGER.error("Failed to control device %s: %s", device_id, err)
 			raise DeviceControlError(f"Failed to control device: {err}") from err
+
+	async def async_ring_device(self, device_id: str, child_id: str | None = None) -> bool:
+		"""Ring a Family Link device (make it sound to help locate it).
+
+		Uses the devices/{device_id}:executeRemoteAction endpoint with action
+		code 2 (ring), discovered from the Family Link web UI.
+
+		Args:
+			device_id: Device ID to ring
+			child_id: Child's user ID (optional, defaults to first supervised child)
+
+		Returns:
+			True if the ring command was accepted, False otherwise
+		"""
+		if not self.is_authenticated():
+			raise AuthenticationError("Not authenticated")
+
+		self._validate_id(device_id, "device_id")
+
+		try:
+			session = await self._get_session()
+			cookie_header = self._get_cookie_header()
+
+			# Get supervised child account ID
+			if child_id is None:
+				account_id = await self.async_get_supervised_child_id()
+			else:
+				account_id = child_id
+
+			# Payload format from the web UI:
+			# [null, account_id, device_id, [<action_code>, null, device_id, 0]]
+			payload = json.dumps([
+				None,
+				account_id,
+				device_id,
+				[DEVICE_RING_ACTION_CODE, None, device_id, 0],
+			])
+
+			url = self._people_url(account_id, f"devices/{device_id}:executeRemoteAction")
+			_LOGGER.debug(f"Requesting device ring: POST {url}")
+			_LOGGER.debug(f"Payload: {payload}")
+
+			async with session.post(
+				url,
+				headers={
+					"Content-Type": "application/json+protobuf",
+					"Cookie": cookie_header
+				},
+				data=payload
+			) as response:
+				_LOGGER.debug(f"Response status: {response.status}")
+
+				if response.status != 200:
+					response_text = await response.text()
+					_LOGGER.error(f"Device ring failed {response.status}: {response_text}")
+					return False
+
+				response_data = await response.json()
+				_LOGGER.debug(f"Device ring response: {response_data}")
+				_LOGGER.info(f"Successfully rang device {device_id}")
+				return True
+
+		except Exception as err:
+			_LOGGER.error("Failed to ring device %s: %s", device_id, err)
+			raise DeviceControlError(f"Failed to ring device: {err}") from err
 
 	async def async_get_applied_time_limits(self, account_id: str | None = None) -> dict[str, Any]:
 		"""Get applied time limits for all devices (time remaining, windows, etc.).

--- a/custom_components/familylink/const.py
+++ b/custom_components/familylink/const.py
@@ -35,6 +35,10 @@ COOKIE_EXPIRY_BUFFER: Final = 3600  # 1 hour buffer before expiry
 DEVICE_LOCK_ACTION: Final = "lock"
 DEVICE_UNLOCK_ACTION: Final = "unlock"
 
+# Remote action codes (executeRemoteAction endpoint), discovered from the
+# Family Link web UI. Code 2 = ring/find the device (make it sound).
+DEVICE_RING_ACTION_CODE: Final = 2
+
 # Error codes
 ERROR_AUTH_FAILED: Final = "auth_failed"
 ERROR_TIMEOUT: Final = "timeout"
@@ -75,3 +79,6 @@ SERVICE_SET_BEDTIME: Final = "set_bedtime"
 
 # Location services
 SERVICE_REFRESH_LOCATION: Final = "refresh_location"
+
+# Device remote actions
+SERVICE_RING_DEVICE: Final = "ring_device"

--- a/custom_components/familylink/services.yaml
+++ b/custom_components/familylink/services.yaml
@@ -399,3 +399,31 @@ refresh_location:
       example: "123456789012345678901"
       selector:
         text:
+
+ring_device:
+  name: Ring Device
+  description: Make a Family Link device ring (sound) to help locate it. Select a device entity OR provide device_id/child_id manually.
+  fields:
+    entity_id:
+      name: Device Entity
+      description: Select a Family Link device entity (recommended - automatically extracts device_id and child_id)
+      required: false
+      selector:
+        entity:
+          integration: familylink
+          domain: button
+    device_id:
+      name: Device ID (manual)
+      description: Device ID (device token) - only needed if not using entity selector
+      required: false
+      example: "ABCD1234567890"
+      selector:
+        text:
+    child_id:
+      name: Child ID (manual)
+      description: Child's user ID - only needed if not using entity selector
+      required: false
+      example: "123456789012345678901"
+      selector:
+        text:
+


### PR DESCRIPTION
Family Link's web UI can make a child device ring to help locate it. This exposes the same capability in Home Assistant:

- client: async_ring_device() posts action code 2 to the devices/{id}:executeRemoteAction endpoint, reusing the existing session auth (cookies + X-Goog-Api-Key) and _people_url() validation
- a RingDeviceButton (mdi:bell-ring) is created per device, alongside the existing time-bonus buttons
- a familylink.ring_device service mirrors the other device services (device_id or entity_id, optional child_id), declared in services.yaml

Verified end-to-end on a test tablet: button press -> "Successfully rang device" -> device actually rang. lock/unlock and time-bonus paths re-validated on the same device after deploy.