### PR TITLE
Second optimization pass: fix service-unload leak, drop dead code, document standalone mode

### DIFF
--- a/custom_components/familylink/__init__.py
+++ b/custom_components/familylink/__init__.py
@@ -895,6 +895,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 			hass.services.async_remove(DOMAIN, SERVICE_SET_DAILY_LIMIT)
 			hass.services.async_remove(DOMAIN, SERVICE_SET_BEDTIME)
 			hass.services.async_remove(DOMAIN, SERVICE_REFRESH_LOCATION)
+			hass.services.async_remove(DOMAIN, SERVICE_RING_DEVICE)
 			_LOGGER.debug("Family Link services unregistered")
 
 	return unload_ok

--- a/custom_components/familylink/coordinator.py
+++ b/custom_components/familylink/coordinator.py
@@ -536,10 +536,6 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 			del self._pending_time_limit_states[child_id][limit_type]
 			return None
 
-	async def async_get_device(self, device_id: str) -> dict[str, Any] | None:
-		"""Get device data by ID."""
-		return self._devices.get(device_id)
-
 	async def _create_auth_notification(self) -> None:
 		"""Create a persistent notification when authentication fails (only once)."""
 		if self._auth_notification_sent:

--- a/familylink-playwright/README.md
+++ b/familylink-playwright/README.md
@@ -1,8 +1,10 @@
 # Google Family Link Auth Add-on
 
-![Version](https://img.shields.io/badge/version-1.6.0-blue.svg)
+![Version](https://img.shields.io/badge/version-1.7.0-blue.svg)
 
 A Home Assistant add-on that provides browser-based authentication for the Google Family Link integration.
+
+> **Running Home Assistant Core or Container (no Supervisor)?** This service can also run as a plain Docker container — see [Standalone Docker (no Supervisor)](#standalone-docker-no-supervisor) below, or the full [Docker Standalone Guide](../DOCKER_STANDALONE.md).
 
 ## About
 
@@ -183,6 +185,35 @@ The add-on uses Playwright with Chromium running on a virtual display (Xvfb):
 
 **Why noVNC is needed**: The browser runs headless inside the Docker container. noVNC allows you to see and interact with it remotely through your web browser.
 
+## Standalone Docker (no Supervisor)
+
+If you run **Home Assistant Core** or **Home Assistant Container** (i.e. without the Supervisor / add-on store), you can run this auth service as a plain Docker container instead of as an add-on. The integration then talks to it over the HTTP API (`/api/cookies`) — no shared volume with HA is required.
+
+### Quick start with Docker Compose
+
+A ready-to-use [`docker-compose.standalone.yml`](docker-compose.standalone.yml) is included:
+
+```bash
+docker compose -f docker-compose.standalone.yml up -d
+```
+
+This starts the service with the API on port `8099` and noVNC on port `6080`, persisting encrypted cookies in `./data` (mounted at `/share/familylink`). Authenticate exactly as with the add-on by opening `http://<docker-host-ip>:6080/vnc.html`.
+
+When adding the integration in Home Assistant, point it at the container's URL: `http://<docker-host-ip>:8099`.
+
+### API key protection (1.7.0+)
+
+Since **1.7.0**, the `/api/cookies` endpoint is **always** protected by an API key, so a supervised child on the LAN can no longer fetch the parent's Google session cookies.
+
+- **HA OS / Supervised:** zero-config — a key is auto-generated on first start and persisted (mode `0600`) at `/share/familylink/api_key`; the integration reads it automatically from the shared directory.
+- **Standalone Docker:** the integration cannot read that shared file, so you must pass the key in the integration URL:
+  `http://<docker-host-ip>:8099?api_key=<key>`
+  Find the key in the container logs on first start, or read it from the mounted `./data/api_key` file. You can also set a fixed key yourself with the `API_KEY` environment variable (overrides the auto-generated one).
+
+> The config flow shows a dedicated **"invalid API key"** error if the key is missing or wrong on a protected endpoint.
+
+See the full [Docker Standalone Guide](../DOCKER_STANDALONE.md) for reverse-proxy notes, environment variables, and troubleshooting.
+
 ## Troubleshooting
 
 ### Add-on Won't Start
@@ -225,6 +256,14 @@ The add-on uses Playwright with Chromium running on a virtual display (Xvfb):
 - **Discussions**: [GitHub Discussions](https://github.com/noiwid/HAFamilyLink/discussions)
 
 ## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for the full history. Highlights:
+
+### v1.7.0
+
+- `/api/cookies` is now **always** protected by an API key (auto-generated and persisted with `0600` perms, or overridable via the `API_KEY` env var), closing a LAN cookie-leak hole
+- Standalone Docker: pass the key via `http://<host>:8099?api_key=<key>`; clearer config-flow error and startup hint
+- Bug fixes and hardening across the add-on and integration
 
 ### v1.0.0 (2025-01-07)
 


### PR DESCRIPTION
## Summary
A second, complementary optimization/cleanup pass on top of PR #120, kept deliberately small and low-risk. All integration changes were **verified live against a running v1.2.7 instance** (config-entry reload, `ring_device` service + button, `add_time_bonus` +15min and `reset_bonus` cancel â€” full round trip to Google, sensors read back correctly, device restored to original state).

## Changes
- **`__init__.py` â€” fix service-unload leak (real bug):** `async_unload_entry` removed every familylink service except `ring_device` (added in #121). On the last config-entry unload the ring service stayed registered, leaking across reloads. Adds the missing `async_remove`.
- **`coordinator.py` â€” drop dead, broken method:** `async_get_device()` had no callers and was broken regardless â€” it looked up bare device ids in `self._devices`, whose keys are composite `f"{child_id}_{device_id}"`. The `self._devices` dict itself is kept (still used by the cache-fallback path).
- **`familylink-playwright/README.md` â€” document standalone mode:** the add-on README claimed HA OS/Supervised as a hard prerequisite and never mentioned the standalone Docker mode the repo already ships (`Dockerfile.standalone`, `docker-compose.standalone.yml`, `run-standalone.sh`). Adds a *Standalone Docker (no Supervisor)* section, documents the always-on `/api/cookies` API key (1.7.0) and the `?api_key=` standalone usage, bumps the stale `1.6.0` badge to `1.7.0`, and refreshes the changelog.

## Test plan
- [x] Config entry reload â€” clean, no errors (exercises unloadâ†’setup, the path the fix touches)
- [x] `familylink.ring_device` (service) and `button.*_ring` â€” both reached Google, logged success
- [x] `+15min` bonus written to Google, `active_bonus` sensor read back `15`
- [x] `reset_bonus` cancelled at Google, sensor back to `0`, button availability logic correct
- [x] All entities healthy throughout (cache correctly held through a transient Google HTTP 503)

## Notes
A deeper coordinator-index refactor (O(1) child/device lookups) and hot-path lazy logging were considered but deferred â€” higher regression surface on a production integration, low marginal benefit. Scope kept to correctness + docs.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
