### PR TITLE
Fix: Add Supervisor-based addon discovery for HAOS installations

### DIFF
--- a/custom_components/familylink/auth/addon_client.py
+++ b/custom_components/familylink/auth/addon_client.py
@@ -255,8 +255,9 @@ class AddonCookieClient:
 
         Priority:
         1. Custom URL (if configured)
-        2. Default local API (localhost:8099)
-        3. File fallback (/share/familylink/)
+        2. Supervisor-resolved addon URL (HAOS installations)
+        3. Default local API (localhost:8099)
+        4. File fallback (/share/familylink/)
         """
         # 1. If custom URL is configured, use it
         if self.auth_url:

--- a/custom_components/familylink/auth/addon_client.py
+++ b/custom_components/familylink/auth/addon_client.py
@@ -13,6 +13,10 @@ from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
 
+# Addon slug suffix (the hash prefix is derived from the repository URL)
+_ADDON_SLUG_SUFFIX = "familylink-playwright"
+_ADDON_PORT = 8099
+
 # Default URL for local add-on (Home Assistant OS/Supervised)
 DEFAULT_AUTH_URL = "http://localhost:8099"
 
@@ -46,6 +50,7 @@ class AddonCookieClient:
         self.key_file = self.SHARE_DIR / self.KEY_FILE
         self.api_key_file = self.SHARE_DIR / self.API_KEY_FILE
         self._detected_url: str | None = None
+        self._supervisor_url_resolved = False
         self.last_fetch_status: int | None = None  # HTTP status of last cookie fetch
 
     async def _get_api_key(self) -> str | None:
@@ -64,6 +69,55 @@ class AddonCookieClient:
                 return None
 
         return await self.hass.async_add_executor_job(_read_key_file)
+
+    async def _resolve_addon_url(self) -> str | None:
+        """Resolve addon URL via Supervisor API.
+
+        On HAOS, addon containers are not reachable via localhost.
+        Each addon gets a Docker DNS hostname derived from its slug
+        (underscores replaced with hyphens).
+        """
+        import os
+
+        token = os.environ.get("SUPERVISOR_TOKEN")
+        if not token:
+            return None
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    "http://supervisor/addons",
+                    headers={"Authorization": f"Bearer {token}"},
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status != 200:
+                        return None
+                    data = await resp.json()
+                    addons = data.get("data", {}).get("addons", [])
+                    for addon in addons:
+                        slug = addon.get("slug", "")
+                        if (
+                            slug.endswith(_ADDON_SLUG_SUFFIX)
+                            and addon.get("state") == "started"
+                        ):
+                            hostname = slug.replace("_", "-")
+                            url = f"http://{hostname}:{_ADDON_PORT}"
+                            _LOGGER.debug(
+                                "Resolved addon URL via Supervisor: %s", url
+                            )
+                            return url
+        except Exception as err:
+            _LOGGER.debug("Could not resolve addon URL via Supervisor: %s", err)
+        return None
+
+    async def _get_addon_url(self) -> str:
+        """Get the addon base URL, resolving via Supervisor if needed."""
+        if not self._supervisor_url_resolved:
+            self._supervisor_url_resolved = True
+            resolved = await self._resolve_addon_url()
+            if resolved:
+                self._detected_url = resolved
+                _LOGGER.info("Addon URL resolved via Supervisor: %s", resolved)
+        return self._detected_url or self.auth_url or DEFAULT_AUTH_URL
 
     async def _fetch_cookies_from_url(self, url: str) -> list[dict[str, Any]] | None:
         """Fetch cookies from auth server API.
@@ -176,17 +230,24 @@ class AddonCookieClient:
             if await self._check_url_available(self.auth_url):
                 self._detected_url = self.auth_url
                 return ("api", self.auth_url)
-
-        # 2. Try default local URL (add-on)
+                
+        # 2. Resolve addon URL via Supervisor API (Docker hostname)
+        supervisor_url = await self._resolve_addon_url()
+        if supervisor_url and await self._check_url_available(supervisor_url):
+            self._detected_url = supervisor_url
+            _LOGGER.info("Addon detected via Supervisor at %s", supervisor_url)
+            return ("api", supervisor_url)
+            
+        # 3. Try default local URL (standalone / Docker Compose)
         if await self._check_url_available(DEFAULT_AUTH_URL):
             self._detected_url = DEFAULT_AUTH_URL
             return ("api", DEFAULT_AUTH_URL)
 
-        # 3. Fallback to file
+        # 4. Fallback to file
         if await self._file_available():
             return ("file", None)
 
-        # 4. Nothing available
+        # 5. Nothing available
         return ("none", None)
 
     async def load_cookies(self) -> list[dict[str, Any]] | None:
@@ -203,13 +264,20 @@ class AddonCookieClient:
             if cookies is not None:
                 return cookies
             _LOGGER.warning(f"Failed to load cookies from configured URL: {self.auth_url}")
+            
+        # 2. Try the Supervisor-resolved addon URL (HAOS installations)
+        resolved_url = await self._get_addon_url()
+        if resolved_url and resolved_url != self.auth_url:
+            cookies = await self._fetch_cookies_from_url(resolved_url)
+            if cookies is not None:
+                return cookies
 
-        # 2. Try default local API
+        # 3. Try default local API (standalone / Docker Compose)
         cookies = await self._fetch_cookies_from_url(DEFAULT_AUTH_URL)
         if cookies is not None:
             return cookies
 
-        # 3. Fallback to file
+        # 4. Fallback to file
         _LOGGER.debug("API not available, trying file fallback")
         return await self._load_cookies_from_file()
 


### PR DESCRIPTION
### Problem

On Home Assistant OS, the Family Link integration cannot connect to the
`familylink-playwright` addon. The integration only tries `localhost:8099`,
but on HAOS addon containers run in isolated Docker networks and are not
reachable via localhost.

The [Microsoft Family Safety integration already implements this](https://github.com/noiwid/HAFamilySafety/blob/main/custom_components/microsoft_family_safety/auth/addon_client.py) with `_resolve_addon_url()`.

### Root cause

Addon containers get a Docker DNS hostname derived from their slug, with
underscores replaced by hyphens (e.g. slug `a0d7b954_familylink-playwright`
→ hostname `a0d7b954-familylink-playwright`). The integration doesn't query
the Supervisor API to discover this hostname.

### Changes

**File**: `custom_components/familylink/auth/addon_client.py`

- Added `_resolve_addon_url()` — queries Supervisor `/addons` endpoint, finds
  the addon by slug suffix, derives Docker hostname via `slug.replace("_", "-")`
- Added `_get_addon_url()` — caches the resolved URL
- Updated `detect_auth_source()` and `load_cookies()` — inserted Supervisor
  discovery as step 2 between custom URL and localhost fallback

Discovery priority (unchanged for non-HAOS setups):
1. Custom URL (if configured)
2. **Supervisor-resolved Docker hostname (new)**
3. `localhost:8099` (standalone / Docker Compose)
4. Encrypted file fallback

### Testing

- Verified on HAOS 17.3 (qemux86-64, Hyper-V)
- Cookies load successfully via Supervisor-resolved URL
- No regression for standalone/Docker Compose setups (localhost path still works)
- All existing features preserved (API key URL params, `last_fetch_status`,
  file fallback, `clear_cookies()`)