### PR TITLE
Add read-only Family Link schedule sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- Read-only child-level schedule sensors for bedtime, school time, and daily limits. These use the existing coordinator data from Google's `timeLimit` response and do not add extra polling per sensor.
+
+---
+
 ## [1.2.7-rc5] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ This integration uses unofficial, reverse-engineered Google Family Link API endp
 - `switch.<child>_school_time` - Enable/disable school time restrictions
 - `switch.<child>_daily_limit` - Enable/disable daily screen time limit
 
+#### Schedule Sensors
+- `sensor.<child>_bedtime_schedule` - Weekly bedtime schedule
+- `sensor.<child>_school_time_schedule` - Weekly school time schedule
+- `sensor.<child>_daily_limit_schedule` - Weekly daily limit schedule
+  - Attributes: `enabled`, `enabled_days`, `schedule`, `monday` through `sunday`
+
 ### Per-Device Entities
 
 #### Sensors

--- a/custom_components/familylink/client/api.py
+++ b/custom_components/familylink/client/api.py
@@ -28,6 +28,7 @@ from ..exceptions import (
 	NetworkError,
 	SessionExpiredError,
 )
+from ..schedules import parse_daily_limit_schedule, parse_window_schedule_items
 
 _LOGGER = logging.getLogger(LOGGER_NAME)
 
@@ -2304,6 +2305,7 @@ class FamilyLinkClient:
 			- school_time_enabled: Boolean
 			- bedtime_schedule: List of {day, start, end} dicts
 			- school_time_schedule: List of {day, start, end} dicts
+			- daily_limit_schedule: List of {day, minutes} dicts
 		"""
 		if not self.is_authenticated():
 			raise AuthenticationError("Not authenticated")
@@ -2351,6 +2353,7 @@ class FamilyLinkClient:
 						"bedtime_enabled_today": None,
 						"bedtime_schedule": [],
 						"school_time_schedule": [],
+						"daily_limit_schedule": [],
 						"bedtime_rule_id": None,
 						"schooltime_rule_id": None
 					}
@@ -2367,6 +2370,7 @@ class FamilyLinkClient:
 						"bedtime_enabled_today": None,
 						"bedtime_schedule": [],
 						"school_time_schedule": [],
+						"daily_limit_schedule": [],
 						"bedtime_rule_id": None,
 						"schooltime_rule_id": None
 					}
@@ -2377,6 +2381,7 @@ class FamilyLinkClient:
 				# Parse bedtime and schooltime schedules
 				bedtime_schedule = []
 				school_time_schedule = []
+				daily_limit_schedule = []
 
 				# The response structure after unwrapping is:
 				# data = [bedtime_config, daily_limit_config, history, None, [1], [current_states]]
@@ -2408,26 +2413,11 @@ class FamilyLinkClient:
 					bedtime_config = data[0]
 					# schedules are the flat list at index 1
 					if len(bedtime_config) > 1 and isinstance(bedtime_config[1], list):
-						for item in bedtime_config[1]:
-							if not (isinstance(item, list) and len(item) >= 5):
-								continue
-							code = item[0]
-							if not isinstance(code, str):
-								continue
-							day = item[1] if len(item) > 1 else None
-							start = item[3] if len(item) > 3 else None
-							end = item[4] if len(item) > 4 else None
-							if not (day and isinstance(start, list) and isinstance(end, list)):
-								continue
-							slot = {
-								"day": day,
-								"start": start,  # [hh, mm]
-								"end": end,  # [hh, mm]
-							}
-							if code.startswith("CAEQ"):
-								bedtime_schedule.append(slot)
-							elif code.startswith("CAMQ"):
-								school_time_schedule.append(slot)
+						bedtime_schedule = parse_window_schedule_items(bedtime_config[1], "CAEQ")
+						school_time_schedule = parse_window_schedule_items(bedtime_config[1], "CAMQ")
+
+				if isinstance(data, list) and len(data) > 1:
+					daily_limit_schedule = parse_daily_limit_schedule(data[1])
 
 				# Parse revisions to get ON/OFF state and rule IDs
 				# Revisions are in the last element of data, containing items with format:
@@ -2567,7 +2557,8 @@ class FamilyLinkClient:
 				_LOGGER.info(
 					f"Time limit rules: bedtime_enabled={bedtime_enabled} (rule_id={bedtime_rule_id}, {len(bedtime_schedule)} schedules), "
 					f"bedtime_enabled_today={bedtime_enabled_today}, "
-					f"school_time_enabled={school_time_enabled} (rule_id={schooltime_rule_id}, {len(school_time_schedule)} schedules)"
+					f"school_time_enabled={school_time_enabled} (rule_id={schooltime_rule_id}, {len(school_time_schedule)} schedules), "
+					f"daily_limit_schedule={len(daily_limit_schedule)} entries"
 				)
 
 				return {
@@ -2579,6 +2570,7 @@ class FamilyLinkClient:
 					"bedtime_enabled_today": bedtime_enabled_today,
 					"bedtime_schedule": bedtime_schedule,
 					"school_time_schedule": school_time_schedule,
+					"daily_limit_schedule": daily_limit_schedule,
 					"bedtime_rule_id": bedtime_rule_id,
 					"schooltime_rule_id": schooltime_rule_id
 				}

--- a/custom_components/familylink/coordinator.py
+++ b/custom_components/familylink/coordinator.py
@@ -214,6 +214,7 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 			school_time_enabled = None
 			bedtime_schedule = None
 			school_time_schedule = None
+			daily_limit_schedule = None
 			# Today-effective bedtime state derived from the per-day type-9
 			# override in the timeLimit response (issue #113). This is the
 			# authoritative source for the bedtime switch — it reflects the
@@ -228,6 +229,7 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 				bedtime_enabled_today_from_rules = time_limit_config.get("bedtime_enabled_today")
 				bedtime_schedule = time_limit_config.get("bedtime_schedule")
 				school_time_schedule = time_limit_config.get("school_time_schedule")
+				daily_limit_schedule = time_limit_config.get("daily_limit_schedule")
 				_LOGGER.debug(
 					f"Fetched time limit config for {child_name}: "
 					f"bedtime={bedtime_enabled}, bedtime_today={bedtime_enabled_today_from_rules}, "
@@ -246,6 +248,7 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 							bedtime_enabled_today_from_rules = cached_child.get("bedtime_enabled_today")
 							bedtime_schedule = cached_child.get("bedtime_schedule")
 							school_time_schedule = cached_child.get("school_time_schedule")
+							daily_limit_schedule = cached_child.get("daily_limit_schedule")
 							_LOGGER.debug(f"Using cached time limit config for {child_name}")
 							break
 
@@ -411,6 +414,7 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 				"school_time_enabled_today": schooltime_enabled_today,
 				"bedtime_schedule": bedtime_schedule,
 				"school_time_schedule": school_time_schedule,
+				"daily_limit_schedule": daily_limit_schedule,
 				"daily_limit_enabled": daily_limit_enabled,
 				"devices_time_data": devices_time_data,
 			}

--- a/custom_components/familylink/schedules.py
+++ b/custom_components/familylink/schedules.py
@@ -1,0 +1,122 @@
+"""Schedule parsing helpers for Google Family Link responses."""
+from __future__ import annotations
+
+from typing import Any
+
+DAY_NAMES = {
+	1: "Monday",
+	2: "Tuesday",
+	3: "Wednesday",
+	4: "Thursday",
+	5: "Friday",
+	6: "Saturday",
+	7: "Sunday",
+}
+
+
+def _is_int(value: Any) -> bool:
+	"""Return true for plain integers, excluding booleans."""
+	return type(value) is int
+
+
+def _is_time_pair(value: Any) -> bool:
+	"""Return true for [hour, minute] pairs."""
+	return (
+		isinstance(value, list)
+		and len(value) == 2
+		and _is_int(value[0])
+		and _is_int(value[1])
+		and 0 <= value[0] <= 23
+		and 0 <= value[1] <= 59
+	)
+
+
+def format_time_pair(value: list[int]) -> str:
+	"""Format a [hour, minute] pair as HH:MM."""
+	return f"{value[0]:02d}:{value[1]:02d}"
+
+
+def parse_window_schedule_items(items: Any, code_prefix: str) -> list[dict[str, Any]]:
+	"""Parse bedtime or school time rows from a timeLimit schedule list."""
+	schedules: list[dict[str, Any]] = []
+
+	if not isinstance(items, list):
+		return schedules
+
+	for item in items:
+		if not (isinstance(item, list) and len(item) >= 5):
+			continue
+
+		code = item[0]
+		day = item[1] if len(item) > 1 else None
+		state_flag = item[2] if len(item) > 2 else None
+		start = item[3] if len(item) > 3 else None
+		end = item[4] if len(item) > 4 else None
+
+		if not (
+			isinstance(code, str)
+			and code.startswith(code_prefix)
+			and _is_int(day)
+			and day in DAY_NAMES
+			and _is_int(state_flag)
+			and _is_time_pair(start)
+			and _is_time_pair(end)
+		):
+			continue
+
+		schedules.append({
+			"day": day,
+			"day_name": DAY_NAMES[day],
+			"enabled": state_flag == 2,
+			"start": start,
+			"end": end,
+			"state_flag": state_flag,
+		})
+
+	return sorted(schedules, key=lambda slot: slot["day"])
+
+
+def _walk_lists(value: Any):
+	"""Yield nested lists from a response fragment."""
+	if not isinstance(value, list):
+		return
+
+	yield value
+	for item in value:
+		if isinstance(item, list):
+			yield from _walk_lists(item)
+
+
+def parse_daily_limit_schedule(config: Any) -> list[dict[str, Any]]:
+	"""Parse daily limit rows from the timeLimit daily limit config block."""
+	schedules_by_day: dict[int, dict[str, Any]] = {}
+
+	for item in _walk_lists(config):
+		if len(item) < 4:
+			continue
+
+		code = item[0]
+		day = item[1] if len(item) > 1 else None
+		state_flag = item[2] if len(item) > 2 else None
+		minutes = item[3] if len(item) > 3 else None
+
+		if not (
+			isinstance(code, str)
+			and code.startswith("CAEQ")
+			and _is_int(day)
+			and day in DAY_NAMES
+			and _is_int(state_flag)
+			and _is_int(minutes)
+			and minutes >= 0
+		):
+			continue
+
+		schedules_by_day[day] = {
+			"day": day,
+			"day_name": DAY_NAMES[day],
+			"enabled": state_flag == 2 and minutes > 0,
+			"minutes": minutes,
+			"state_flag": state_flag,
+		}
+
+	return [schedules_by_day[day] for day in sorted(schedules_by_day)]

--- a/custom_components/familylink/sensor.py
+++ b/custom_components/familylink/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_ENABLE_LOCATION_TRACKING, DOMAIN, LOGGER_NAME
 from .coordinator import FamilyLinkDataUpdateCoordinator
+from .schedules import DAY_NAMES, format_time_pair
 
 _LOGGER = logging.getLogger(LOGGER_NAME)
 
@@ -98,6 +99,36 @@ async def async_setup_entry(
         # Device sensors
         entities.append(FamilyLinkDeviceCountSensor(coordinator, child_id, child_name))
         entities.append(FamilyLinkChildInfoSensor(coordinator, child_id, child_name))
+        entities.append(FamilyLinkScheduleSensor(
+            coordinator,
+            child_id,
+            child_name,
+            "Bedtime Schedule",
+            "bedtime_schedule",
+            "bedtime_enabled",
+            "mdi:weather-night",
+            "window",
+        ))
+        entities.append(FamilyLinkScheduleSensor(
+            coordinator,
+            child_id,
+            child_name,
+            "School Time Schedule",
+            "school_time_schedule",
+            "school_time_enabled",
+            "mdi:school-outline",
+            "window",
+        ))
+        entities.append(FamilyLinkScheduleSensor(
+            coordinator,
+            child_id,
+            child_name,
+            "Daily Limit Schedule",
+            "daily_limit_schedule",
+            None,
+            "mdi:calendar-clock",
+            "minutes",
+        ))
 
         # Battery sensor (only if location tracking is enabled, as battery comes from location data)
         if entry.options.get(CONF_ENABLE_LOCATION_TRACKING, entry.data.get(CONF_ENABLE_LOCATION_TRACKING, False)):
@@ -383,6 +414,112 @@ class NextRestrictionSensor(CoordinatorEntity, SensorEntity):
                                     attributes["schooltime_end"] = datetime.fromtimestamp(end_ms / 1000).isoformat()
                                 except (ValueError, OSError):
                                     pass
+
+        return attributes
+
+
+class FamilyLinkScheduleSensor(ChildDataMixin, CoordinatorEntity, SensorEntity):
+    """Read-only weekly schedule sensor."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: FamilyLinkDataUpdateCoordinator,
+        child_id: str,
+        child_name: str,
+        name_suffix: str,
+        schedule_key: str,
+        enabled_key: str | None,
+        icon: str,
+        schedule_type: str,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator=coordinator, child_id=child_id, child_name=child_name)
+        self._schedule_key = schedule_key
+        self._enabled_key = enabled_key
+        self._schedule_type = schedule_type
+        self._attr_name = f"{child_name} {name_suffix}"
+        self._attr_unique_id = f"{DOMAIN}_{child_id}_{schedule_key}"
+        self._attr_icon = icon
+
+    def _get_schedule(self) -> list[dict[str, Any]]:
+        """Return schedule data for this child."""
+        child_data = self._get_child_data()
+        if not child_data:
+            return []
+        schedule = child_data.get(self._schedule_key)
+        return schedule if isinstance(schedule, list) else []
+
+    def _is_enabled(self, schedule: list[dict[str, Any]]) -> bool | None:
+        """Return the schedule enabled state."""
+        child_data = self._get_child_data()
+        if not child_data:
+            return None
+
+        if self._enabled_key:
+            enabled = child_data.get(self._enabled_key)
+            if isinstance(enabled, bool):
+                return enabled
+
+        if not schedule:
+            return None
+
+        return any(slot.get("enabled") for slot in schedule)
+
+    def _format_slot(self, slot: dict[str, Any]) -> str:
+        """Return a compact day value."""
+        if self._schedule_type == "minutes":
+            minutes = slot.get("minutes")
+            if not slot.get("enabled") or not isinstance(minutes, int) or minutes <= 0:
+                return "off"
+            return f"{minutes} min"
+
+        start = slot.get("start")
+        end = slot.get("end")
+        if not slot.get("enabled") or not isinstance(start, list) or not isinstance(end, list):
+            return "off"
+        return f"{format_time_pair(start)}-{format_time_pair(end)}"
+
+    @property
+    def native_value(self) -> str:
+        """Return enabled, disabled, or unknown."""
+        schedule = self._get_schedule()
+        enabled = self._is_enabled(schedule)
+        if enabled is None:
+            return "unknown"
+        return "enabled" if enabled else "disabled"
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.coordinator.last_update_success and self._get_child_data() is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        schedule = self._get_schedule()
+        enabled = self._is_enabled(schedule)
+        slots_by_day = {
+            slot.get("day"): slot
+            for slot in schedule
+            if isinstance(slot, dict) and isinstance(slot.get("day"), int)
+        }
+        attributes: dict[str, Any] = {
+            "child_id": self._child_id,
+            "child_name": self._child_name,
+			"enabled": enabled,
+			"enabled_days": [
+				slot.get("day_name")
+				for slot in schedule
+				if isinstance(slot, dict) and slot.get("enabled") and slot.get("day_name")
+			],
+			"schedule": schedule,
+		}
+
+        for day, day_name in DAY_NAMES.items():
+            slot = slots_by_day.get(day)
+            attributes[day_name.lower()] = self._format_slot(slot) if slot else "off"
 
         return attributes
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8.0
+pytest-asyncio>=0.23

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1,0 +1,98 @@
+"""Tests for Family Link schedule parsing helpers."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = (
+	Path(__file__).parents[1]
+	/ "custom_components"
+	/ "familylink"
+	/ "schedules.py"
+)
+spec = importlib.util.spec_from_file_location("familylink_schedules", MODULE_PATH)
+schedules = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(schedules)
+
+
+def test_parse_window_schedule_items_splits_enabled_and_disabled_rows():
+	items = [
+		["CAEQAQ", 1, 2, [21, 0], [6, 30], "1", "2", "bedtime-rule"],
+		["CAMQAg", 2, 1, [8, 15], [13, 45], "1", "2", "school-rule"],
+		["CAEQAw", 3, 1, [22, 0], [7, 0], "1", "2", "bedtime-rule"],
+		["CAEQBA", 4, 2, 21, [7, 0], "bad"],
+		["other", 5, 2, [21, 0], [6, 30]],
+	]
+
+	bedtime = schedules.parse_window_schedule_items(items, "CAEQ")
+	school_time = schedules.parse_window_schedule_items(items, "CAMQ")
+
+	assert bedtime == [
+		{
+			"day": 1,
+			"day_name": "Monday",
+			"enabled": True,
+			"start": [21, 0],
+			"end": [6, 30],
+			"state_flag": 2,
+		},
+		{
+			"day": 3,
+			"day_name": "Wednesday",
+			"enabled": False,
+			"start": [22, 0],
+			"end": [7, 0],
+			"state_flag": 1,
+		},
+	]
+	assert school_time == [
+		{
+			"day": 2,
+			"day_name": "Tuesday",
+			"enabled": False,
+			"start": [8, 15],
+			"end": [13, 45],
+			"state_flag": 1,
+		}
+	]
+
+
+def test_parse_daily_limit_schedule_ignores_malformed_rows():
+	config = [[
+		2,
+		[6, 0],
+		[
+			["CAEQAQ", 1, 2, 90, "1", "2"],
+			["CAEQAg", 2, 1, 45, "1", "2"],
+			["CAEQAw", 3, 2, 0, "1", "2"],
+			["CAEQBA", 4, 2, [21, 0], "bad"],
+		],
+		"created",
+		"updated",
+	]]
+
+	assert schedules.parse_daily_limit_schedule(config) == [
+		{
+			"day": 1,
+			"day_name": "Monday",
+			"enabled": True,
+			"minutes": 90,
+			"state_flag": 2,
+		},
+		{
+			"day": 2,
+			"day_name": "Tuesday",
+			"enabled": False,
+			"minutes": 45,
+			"state_flag": 1,
+		},
+		{
+			"day": 3,
+			"day_name": "Wednesday",
+			"enabled": False,
+			"minutes": 0,
+			"state_flag": 2,
+		},
+	]


### PR DESCRIPTION
## Summary

Adds read-only child-level schedule sensors for Family Link bedtime, school time, and daily limit schedules.

This PR does not add any new write behavior. It only parses schedule data already returned by Google's existing `timeLimit` response and exposes it as Home Assistant diagnostic sensors.

## What changed

- Adds schedule parsing helpers for Family Link `timeLimit` payloads.
- Adds child-level diagnostic sensors:
  - `sensor.<child>_bedtime_schedule`
  - `sensor.<child>_school_time_schedule`
  - `sensor.<child>_daily_limit_schedule`
- Exposes useful attributes such as `enabled`, `enabled_days`, `schedule`, and weekday-specific values.
- Adds focused unit tests for schedule parsing.
- Adds the missing `requirements-dev.txt` referenced by the README so tests can be run locally.
- Updates README and changelog.

## Why

The integration already reads Family Link time-limit configuration internally, but users currently cannot easily inspect the weekly configured schedules from Home Assistant.

These sensors make the configured schedules visible without adding extra API polling and without changing any Family Link state.

## Testing

- `python -m pip install -r requirements-dev.txt`
- `python -m pytest tests/test_schedules.py`

## Follow-ups

If this shape looks acceptable, I can follow up separately with timezone handling, recurring schedule write services, and broader test-suite/CI cleanup to make future contributions easier to review.