### PR TITLE
Remove requirements already included with Home Assistant

### DIFF
--- a/custom_components/familylink/manifest.json
+++ b/custom_components/familylink/manifest.json
@@ -10,8 +10,6 @@
   "config_flow": true,
   "dependencies": [],
   "requirements": [
-    "aiohttp>=3.8.0",
-    "cryptography>=3.4.8"
   ],
   "iot_class": "cloud_polling",
   "integration_type": "hub"


### PR DESCRIPTION
Removed aiohttp and cryptography from requirements, they're already included with home-assistant.

With this component installed, when I upgraded to HA 2026.7.1, several core components failed to load, with the error message `Exception: Version mismatch: this is the 'cffi' package version 2.1.0, located in '/usr/local/lib/python3.14/site-packages/cffi/api.py'.  When we import the top-level '_cffi_backend' extension module, we get version 2.0.0, located in '/usr/local/lib/python3.14/site-packages/_cffi_backend.cpython-314-x86_64-linux-musl.so'.  The two versions should be equal; check your installation.`

This is due to HAFamilyLink specifying these two requirements which are already included with Home Assistant. The documentation states not to include any requirements already listed, because doing so can create these types of broken environments. See https://developers.home-assistant.io/docs/creating_integration_manifest/#custom-integration-requirements