### PR TITLE
Fix location fetch: use numeric LocationRefreshMode enum (Google API change)

### DIFF
--- a/custom_components/familylink/client/api.py
+++ b/custom_components/familylink/client/api.py
@@ -44,6 +44,13 @@ class FamilyLinkClient:
 	# SAPISIDHASH timestamp must stay fresh for Google API authentication
 	SESSION_MAX_AGE = 1800  # 30 minutes
 
+	# LocationRefreshMode enum values for the kidsmanagement location endpoint.
+	# Google changed this field to reject the string names ("REFRESH" /
+	# "DO_NOT_REFRESH") and now only accepts the numeric enum values, so the
+	# string form returns HTTP 400 "Invalid value at 'location_refresh_mode'".
+	LOCATION_REFRESH_MODE_DO_NOT_REFRESH = "1"
+	LOCATION_REFRESH_MODE_REFRESH = "2"
+
 	def __init__(self, hass: HomeAssistant, config: dict[str, Any]) -> None:
 		"""Initialize the Family Link client."""
 		self.hass = hass
@@ -582,7 +589,12 @@ class FamilyLinkClient:
 			self._validate_id(account_id, "account_id")
 			url = f"{self.BASE_URL}/families/mine/location/{account_id}"
 			params = [
-				("locationRefreshMode", "REFRESH" if refresh else "DO_NOT_REFRESH"),
+				(
+					"locationRefreshMode",
+					self.LOCATION_REFRESH_MODE_REFRESH
+					if refresh
+					else self.LOCATION_REFRESH_MODE_DO_NOT_REFRESH,
+				),
 				("supportedConsents", "SUPERVISED_LOCATION_SHARING"),
 			]
 


### PR DESCRIPTION
### Problem
Google's `kidsmanagement` location endpoint no longer accepts the string values `"REFRESH"` / `"DO_NOT_REFRESH"` for `locationRefreshMode`. Requests now fail with:

```
HTTP 400: Invalid value at 'location_refresh_mode'
(type.googleapis.com/google.kidsmanagement.v1.LocationRefreshMode), "REFRESH"
```

Because `async_get_location` returns `None` on a non-200 response, the `device_tracker` silently freezes on the last position that succeeded before Google's change — no error surfaced to the user, just a stale location.

### Fix
Google now requires the numeric enum values. Switched to `2` (REFRESH) / `1` (DO_NOT_REFRESH), both verified returning HTTP 200 against the live API. Added named class constants with an explanatory comment.

### Testing
Reproduced the 400 with the string value and confirmed 200 + a fresh GPS fix with the numeric value, against a live supervised account. Deployed to a running HA instance; `device_tracker` location resumed updating immediately.