### PR TITLE
Fix #136: default to TigerVNC to fix noVNC connect-time crash + surface silent display-stack failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## Add-on / auth container [1.8.0] - 2026-07-24
+
+### Fixed
+- **noVNC no longer hangs on "Connecting…" forever (issue #136).** The auth container's display stack (Xvfb + fluxbox + x11vnc + websockify) was started with all output redirected to `/dev/null` and no real liveness check, so any failure was completely silent: the container stayed "healthy" on uvicorn/8099 while noVNC never rendered. Two concrete failure modes are addressed, plus the underlying crash:
+  - **Silent failures are now visible.** In the standalone container each display process logs to `/var/log/familylink/<proc>.log` instead of `/dev/null`, and its status is re-checked after launch with the last log lines dumped on failure. The add-on entrypoint (already logging to journald) gains the same Xvfb/fluxbox/x11vnc liveness checks.
+  - **Stale X99 state is cleaned on start.** A non-graceful stop (e.g. `docker restart`) left `/tmp/.X11-unix/X99` and `/tmp/.X99-lock` behind, which made `Xvfb :99` silently refuse to bind on the next start and took the whole display stack down invisibly — only uvicorn came back, so the container reported healthy while VNC was dead. Both are now removed before the display server starts (and again before the x11vnc fallback).
+  - **VNC password length.** x11vnc's `-passwd` (and TigerVNC's VncAuth) uses DES and silently keeps only the first 8 characters, so the 10-char default (`familylink`) never authenticated cleanly. The password is now truncated explicitly with a warning, and the web UI's auto-connect URL embeds the same 8-char value so client and server agree. The server stays localhost-only behind websockify.
+
+### Changed
+- **TigerVNC is now the default display backend, with automatic fallback to Xvfb + x11vnc (issue #136).** The primary crash (`x11vnc` 0.9.16 tearing down its own X connection the instant a VNC client connects, confirmed by @wookash via `strace`) is most likely an incompatibility between the 2019 x11vnc build and the bookworm X11 libraries. Rather than chase a compatible x11vnc, the container now prefers **TigerVNC's `Xvnc`** — an X server that speaks the RFB/VNC protocol natively, so there is no separate Xvfb and no x11vnc screen-scraper, removing the exact component that crashed. If `Xvnc` is unavailable or fails to start, the container automatically falls back to the legacy Xvfb + x11vnc stack, so no environment loses VNC. The backend can be forced with `FAMILYLINK_VNC_BACKEND=tigervnc|x11vnc`.
+
+---
+
 ## [1.2.12] - 2026-07-16
 
 ### Fixed

--- a/familylink-playwright/Dockerfile
+++ b/familylink-playwright/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update \
         libasound2 \
         xvfb \
         x11vnc \
+        tigervnc-standalone-server \
         novnc \
         python3-websockify \
         fluxbox \
@@ -79,4 +80,4 @@ LABEL \
     io.hass.name="Google Family Link Auth" \
     io.hass.description="Authentication service for Google Family Link" \
     io.hass.type="addon" \
-    io.hass.version="1.6.1"
+    io.hass.version="1.8.0"

--- a/familylink-playwright/Dockerfile.standalone
+++ b/familylink-playwright/Dockerfile.standalone
@@ -26,6 +26,7 @@ RUN apt-get update \
         libasound2 \
         xvfb \
         x11vnc \
+        tigervnc-standalone-server \
         novnc \
         python3-websockify \
         fluxbox \
@@ -80,7 +81,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
 LABEL \
     org.opencontainers.image.title="Google Family Link Auth (Standalone)" \
     org.opencontainers.image.description="Standalone authentication service for Google Family Link" \
-    org.opencontainers.image.version="1.6.1" \
+    org.opencontainers.image.version="1.8.0" \
     org.opencontainers.image.source="https://github.com/noiwid/HAFamilyLink"
 
 # Start the service

--- a/familylink-playwright/app/main.py
+++ b/familylink-playwright/app/main.py
@@ -153,8 +153,11 @@ async def index():
     t = get_translations(config.language)
     # Only embed the VNC password in the page when it is still the documented
     # default — never leak a custom password on this unauthenticated page.
+    # VNC-auth (both x11vnc and TigerVNC) uses DES and honours only the first 8
+    # chars, and the startup script truncates the password to match; embed the
+    # same truncation so the auto-connect URL agrees with the server (issue #136).
     if config.vnc_password == "familylink":
-        novnc_password_param = "&password=familylink"
+        novnc_password_param = f"&password={config.vnc_password[:8]}"
         novnc_password_hint = t['novnc_password_hint']
     else:
         novnc_password_param = ""

--- a/familylink-playwright/config.json
+++ b/familylink-playwright/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Google Family Link Auth",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "slug": "familylink-playwright",
   "description": "Authentication service for Google Family Link integration using browser automation",
   "url": "https://github.com/noiwid/HAFamilyLink",

--- a/familylink-playwright/rootfs/usr/local/bin/run.sh
+++ b/familylink-playwright/rootfs/usr/local/bin/run.sh
@@ -77,21 +77,46 @@ if [ ! -S /run/dbus/system_bus_socket ]; then
     dbus-daemon --system --fork 2>/dev/null || bashio::log.warning "D-Bus not available (non-critical)"
 fi
 
+# Remove a stale X99 socket/lock left by a previous non-graceful stop (e.g. an
+# add-on restart). If they survive, `Xvfb :99` silently refuses to bind and the
+# whole display stack dies invisibly, leaving only uvicorn up (issue #136).
+if [ -e /tmp/.X99-lock ] || [ -e /tmp/.X11-unix/X99 ]; then
+    bashio::log.info "Cleaning stale X99 lock/socket from a previous run..."
+    rm -f /tmp/.X99-lock /tmp/.X11-unix/X99 2>/dev/null || true
+fi
+
 # Start Xvfb (virtual display)
 # Using 16-bit color depth for better VM compatibility and lower memory usage
 bashio::log.info "Starting virtual display (Xvfb)..."
 Xvfb :99 -screen 0 1280x1024x16 -ac -nolisten tcp &
+XVFB_PID=$!
 export DISPLAY=:99
 
-# Wait for Xvfb to start
+# Wait for Xvfb to start, then confirm it is actually up
 sleep 2
+if ! kill -0 "${XVFB_PID}" 2>/dev/null; then
+    bashio::log.warning "Xvfb failed to start — VNC will be unavailable (see log above)"
+fi
 
 # Start window manager
 fluxbox &
+FLUXBOX_PID=$!
+sleep 1
+if ! kill -0 "${FLUXBOX_PID}" 2>/dev/null; then
+    bashio::log.warning "fluxbox failed to start (non-critical, see log above)"
+fi
 
 # Start VNC server (localhost only) and noVNC web interface
 bashio::log.info "Starting VNC server (localhost only)..."
 VNC_PASSWORD=$(bashio::config 'vnc_password' 'familylink')
+# x11vnc's -passwd uses DES and silently keeps only the first 8 chars; a longer
+# password would then never authenticate. The server is localhost-only and
+# reached through websockify, so truncate explicitly and warn rather than let
+# the mismatch fail silently (issue #136).
+if [ "${#VNC_PASSWORD}" -gt 8 ]; then
+    bashio::log.warning "VNC password longer than 8 chars; x11vnc DES auth uses only the first 8"
+    VNC_PASSWORD="${VNC_PASSWORD:0:8}"
+fi
 # Expose to the FastAPI app so the web UI can adapt the noVNC link/hint
 export VNC_PASSWORD="${VNC_PASSWORD}"
 x11vnc -display :99 -forever -shared -rfbport 5900 -localhost -passwd "${VNC_PASSWORD}" &

--- a/familylink-playwright/rootfs/usr/local/bin/run.sh
+++ b/familylink-playwright/rootfs/usr/local/bin/run.sh
@@ -85,45 +85,120 @@ if [ -e /tmp/.X99-lock ] || [ -e /tmp/.X11-unix/X99 ]; then
     rm -f /tmp/.X99-lock /tmp/.X11-unix/X99 2>/dev/null || true
 fi
 
-# Start Xvfb (virtual display)
-# Using 16-bit color depth for better VM compatibility and lower memory usage
-bashio::log.info "Starting virtual display (Xvfb)..."
-Xvfb :99 -screen 0 1280x1024x16 -ac -nolisten tcp &
-XVFB_PID=$!
 export DISPLAY=:99
 
-# Wait for Xvfb to start, then confirm it is actually up
-sleep 2
-if ! kill -0 "${XVFB_PID}" 2>/dev/null; then
-    bashio::log.warning "Xvfb failed to start — VNC will be unavailable (see log above)"
+# VNC-auth (both x11vnc's -passwd and TigerVNC's VncAuth) uses DES and silently
+# keeps only the first 8 chars; a longer password would then never
+# authenticate. The server is localhost-only and reached through websockify, so
+# truncate explicitly and warn rather than let the mismatch fail silently
+# (issue #136).
+VNC_PASSWORD=$(bashio::config 'vnc_password' 'familylink')
+if [ "${#VNC_PASSWORD}" -gt 8 ]; then
+    bashio::log.warning "VNC password longer than 8 chars; VNC DES auth uses only the first 8"
+    VNC_PASSWORD="${VNC_PASSWORD:0:8}"
+fi
+# Expose to the FastAPI app so the web UI can adapt the noVNC link/hint
+export VNC_PASSWORD="${VNC_PASSWORD}"
+
+# The display server is started in one of two ways (issue #136):
+#
+#   1. TigerVNC's Xvnc — an X server that speaks the RFB (VNC) protocol
+#      natively, so there is no Xvfb and no x11vnc screen-scraper. This removes
+#      the exact component that crashed on client-connect (x11vnc 0.9.16
+#      dropping its X connection). Preferred.
+#   2. Legacy Xvfb + x11vnc — kept as an automatic fallback so we degrade
+#      instead of losing VNC entirely where Xvnc is unavailable.
+#
+# Set FAMILYLINK_VNC_BACKEND=x11vnc (or tigervnc) to force a backend.
+VNC_BACKEND="${FAMILYLINK_VNC_BACKEND:-auto}"
+DISPLAY_STARTED=""
+
+start_tigervnc() {
+    command -v Xvnc >/dev/null 2>&1 || { bashio::log.info "Xvnc not installed"; return 1; }
+
+    # vncpasswd -f is filter mode: reads the plaintext password from stdin and
+    # writes the encrypted file to stdout, so no interactive prompts are needed.
+    local sec_args
+    if [ -n "${VNC_PASSWORD}" ] && command -v vncpasswd >/dev/null 2>&1; then
+        mkdir -p /root/.vnc
+        if printf '%s' "${VNC_PASSWORD}" | vncpasswd -f >/root/.vnc/passwd 2>/dev/null \
+            && [ -s /root/.vnc/passwd ]; then
+            chmod 600 /root/.vnc/passwd 2>/dev/null || true
+            sec_args=(-SecurityTypes VncAuth -rfbauth /root/.vnc/passwd)
+        else
+            bashio::log.warning "vncpasswd failed; starting TigerVNC without a password (localhost only)"
+            sec_args=(-SecurityTypes None)
+        fi
+    else
+        sec_args=(-SecurityTypes None)
+    fi
+
+    bashio::log.info "Starting display server (TigerVNC Xvnc on :99)..."
+    Xvnc :99 -geometry 1280x1024 -depth 24 -rfbport 5900 -localhost \
+        -desktop familylink "${sec_args[@]}" &
+    XVNC_PID=$!
+    sleep 2
+    if kill -0 "${XVNC_PID}" 2>/dev/null; then
+        bashio::log.info "TigerVNC display server started"
+        return 0
+    fi
+    bashio::log.warning "TigerVNC failed to start (see log above)"
+    return 1
+}
+
+start_xvfb_x11vnc() {
+    # A failed TigerVNC attempt can leave :99 state behind, which would block
+    # Xvfb from binding; clear it before falling back.
+    rm -f /tmp/.X99-lock /tmp/.X11-unix/X99 2>/dev/null || true
+    bashio::log.info "Starting virtual display (Xvfb)..."
+    Xvfb :99 -screen 0 1280x1024x16 -ac -nolisten tcp &
+    XVFB_PID=$!
+    sleep 2
+    if ! kill -0 "${XVFB_PID}" 2>/dev/null; then
+        bashio::log.warning "Xvfb failed to start — VNC will be unavailable (see log above)"
+        return 1
+    fi
+
+    bashio::log.info "Starting VNC server (x11vnc, localhost only)..."
+    local pw_args
+    if [ -n "${VNC_PASSWORD}" ]; then
+        pw_args=(-passwd "${VNC_PASSWORD}")
+    else
+        pw_args=(-nopw)
+    fi
+    x11vnc -display :99 -forever -shared -rfbport 5900 -localhost "${pw_args[@]}" &
+    VNC_PID=$!
+    sleep 1
+    if ! kill -0 "${VNC_PID}" 2>/dev/null; then
+        bashio::log.warning "x11vnc failed to start — noVNC will not be available"
+        return 1
+    fi
+    return 0
+}
+
+if [ "${VNC_BACKEND}" = "x11vnc" ]; then
+    start_xvfb_x11vnc && DISPLAY_STARTED="x11vnc"
+elif [ "${VNC_BACKEND}" = "tigervnc" ]; then
+    start_tigervnc && DISPLAY_STARTED="tigervnc"
+else
+    if start_tigervnc; then
+        DISPLAY_STARTED="tigervnc"
+    else
+        bashio::log.info "Falling back to legacy Xvfb + x11vnc display stack..."
+        start_xvfb_x11vnc && DISPLAY_STARTED="x11vnc"
+    fi
 fi
 
-# Start window manager
+if [ -z "${DISPLAY_STARTED}" ]; then
+    bashio::log.warning "No display server could be started — noVNC will not be available"
+fi
+
+# Start window manager on whichever display server came up
 fluxbox &
 FLUXBOX_PID=$!
 sleep 1
 if ! kill -0 "${FLUXBOX_PID}" 2>/dev/null; then
     bashio::log.warning "fluxbox failed to start (non-critical, see log above)"
-fi
-
-# Start VNC server (localhost only) and noVNC web interface
-bashio::log.info "Starting VNC server (localhost only)..."
-VNC_PASSWORD=$(bashio::config 'vnc_password' 'familylink')
-# x11vnc's -passwd uses DES and silently keeps only the first 8 chars; a longer
-# password would then never authenticate. The server is localhost-only and
-# reached through websockify, so truncate explicitly and warn rather than let
-# the mismatch fail silently (issue #136).
-if [ "${#VNC_PASSWORD}" -gt 8 ]; then
-    bashio::log.warning "VNC password longer than 8 chars; x11vnc DES auth uses only the first 8"
-    VNC_PASSWORD="${VNC_PASSWORD:0:8}"
-fi
-# Expose to the FastAPI app so the web UI can adapt the noVNC link/hint
-export VNC_PASSWORD="${VNC_PASSWORD}"
-x11vnc -display :99 -forever -shared -rfbport 5900 -localhost -passwd "${VNC_PASSWORD}" &
-VNC_PID=$!
-sleep 1
-if ! kill -0 "${VNC_PID}" 2>/dev/null; then
-    bashio::log.warning "x11vnc failed to start — noVNC will not be available"
 fi
 
 bashio::log.info "Starting noVNC on port 6080..."
@@ -134,9 +209,9 @@ if ! kill -0 "${NOVNC_PID}" 2>/dev/null; then
     bashio::log.warning "websockify/noVNC failed to start on port 6080"
 fi
 
-# Display a welcome banner on the Xvfb display so noVNC is not black
+# Display a welcome banner on the virtual display so noVNC is not black
 # before the user triggers the authentication flow (issue #108).
-if [ -x /usr/local/bin/welcome-banner.sh ]; then
+if [ -n "${DISPLAY_STARTED}" ] && [ -x /usr/local/bin/welcome-banner.sh ]; then
     /usr/local/bin/welcome-banner.sh || bashio::log.warning "Welcome banner failed to start (non-critical)"
 fi
 

--- a/familylink-playwright/run-standalone.sh
+++ b/familylink-playwright/run-standalone.sh
@@ -65,23 +65,125 @@ if [ -e /tmp/.X99-lock ] || [ -e /tmp/.X11-unix/X99 ]; then
     rm -f /tmp/.X99-lock /tmp/.X11-unix/X99 2>/dev/null || true
 fi
 
-# Start Xvfb (virtual display)
-# Using 16-bit color depth for better VM compatibility and lower memory usage
-echo "Starting virtual display (Xvfb)..."
-Xvfb :99 -screen 0 1280x1024x16 -ac -nolisten tcp >"${LOG_DIR}/xvfb.log" 2>&1 &
-XVFB_PID=$!
-export DISPLAY=:99
-
-# Wait for Xvfb to start, then confirm it is actually up
-sleep 2
-if kill -0 "${XVFB_PID}" 2>/dev/null; then
-    echo "✓ Virtual display started on :99"
-else
-    echo "⚠ Xvfb failed to start — VNC will be unavailable. Last log lines:"
-    tail -n 20 "${LOG_DIR}/xvfb.log" 2>/dev/null | sed 's/^/    xvfb| /'
+# x11vnc's -passwd uses DES and silently keeps only the first 8 chars; a longer
+# password would then never authenticate. The VNC server is localhost-only and
+# reached through websockify, so truncate explicitly and warn rather than let
+# the mismatch fail silently (issue #136). TigerVNC's VNC-auth has the same
+# 8-char limit, so this applies to both display backends below.
+if [ "${#VNC_PASSWORD}" -gt 8 ]; then
+    echo "⚠ VNC password longer than 8 chars; VNC DES auth uses only the first 8."
+    VNC_PASSWORD="${VNC_PASSWORD:0:8}"
 fi
 
-# Start window manager
+export DISPLAY=:99
+
+# The display server is started in one of two ways (issue #136):
+#
+#   1. TigerVNC's Xvnc — an X server that speaks the RFB (VNC) protocol
+#      natively. fluxbox and Chromium render straight into it; websockify
+#      bridges it to noVNC. There is no Xvfb and no x11vnc screen-scraper, which
+#      removes the exact component that crashed on client-connect (x11vnc 0.9.16
+#      dropping its X connection). This is the preferred path.
+#
+#   2. Legacy Xvfb + x11vnc — kept as an automatic fallback for environments
+#      where Xvnc is unavailable or fails to start, so we degrade instead of
+#      losing VNC entirely.
+#
+# Set FAMILYLINK_VNC_BACKEND=x11vnc to force the legacy path.
+VNC_BACKEND="${FAMILYLINK_VNC_BACKEND:-auto}"
+DISPLAY_STARTED=""
+
+start_tigervnc() {
+    command -v Xvnc >/dev/null 2>&1 || { echo "  Xvnc not installed"; return 1; }
+
+    # Build a TigerVNC password file (VNC-auth) unless empty -> no auth.
+    # vncpasswd -f is filter mode: it reads the plaintext password from stdin
+    # and writes the encrypted file to stdout, which is deterministic and needs
+    # no interactive prompts.
+    local sec_args
+    if [ -n "${VNC_PASSWORD}" ] && command -v vncpasswd >/dev/null 2>&1; then
+        mkdir -p /root/.vnc
+        if printf '%s' "${VNC_PASSWORD}" | vncpasswd -f >/root/.vnc/passwd 2>>"${LOG_DIR}/xvnc.log" \
+            && [ -s /root/.vnc/passwd ]; then
+            chmod 600 /root/.vnc/passwd 2>/dev/null || true
+            sec_args=(-SecurityTypes VncAuth -rfbauth /root/.vnc/passwd)
+        else
+            echo "⚠ vncpasswd failed; starting TigerVNC without a password (localhost only)."
+            sec_args=(-SecurityTypes None)
+        fi
+    else
+        sec_args=(-SecurityTypes None)
+    fi
+
+    echo "Starting display server (TigerVNC Xvnc on :99)..."
+    Xvnc :99 -geometry 1280x1024 -depth 24 -rfbport 5900 -localhost \
+        -desktop familylink "${sec_args[@]}" \
+        >"${LOG_DIR}/xvnc.log" 2>&1 &
+    XVNC_PID=$!
+    sleep 2
+    if kill -0 "${XVNC_PID}" 2>/dev/null; then
+        echo "✓ TigerVNC display server started (log: ${LOG_DIR}/xvnc.log)"
+        return 0
+    fi
+    echo "⚠ TigerVNC failed to start. Last log lines:"
+    tail -n 20 "${LOG_DIR}/xvnc.log" 2>/dev/null | sed 's/^/    xvnc| /'
+    return 1
+}
+
+start_xvfb_x11vnc() {
+    # A failed TigerVNC attempt can leave :99 state behind, which would block
+    # Xvfb from binding; clear it before falling back.
+    rm -f /tmp/.X99-lock /tmp/.X11-unix/X99 2>/dev/null || true
+    echo "Starting virtual display (Xvfb)..."
+    Xvfb :99 -screen 0 1280x1024x16 -ac -nolisten tcp >"${LOG_DIR}/xvfb.log" 2>&1 &
+    XVFB_PID=$!
+    sleep 2
+    if ! kill -0 "${XVFB_PID}" 2>/dev/null; then
+        echo "⚠ Xvfb failed to start — VNC will be unavailable. Last log lines:"
+        tail -n 20 "${LOG_DIR}/xvfb.log" 2>/dev/null | sed 's/^/    xvfb| /'
+        return 1
+    fi
+    echo "✓ Virtual display started on :99"
+
+    echo "Starting VNC server (x11vnc, localhost only)..."
+    local pw_args
+    if [ -n "${VNC_PASSWORD}" ]; then
+        pw_args=(-passwd "${VNC_PASSWORD}")
+    else
+        pw_args=(-nopw)
+    fi
+    x11vnc -display :99 -forever -shared -rfbport 5900 -localhost "${pw_args[@]}" \
+        >"${LOG_DIR}/x11vnc.log" 2>&1 &
+    VNC_PID=$!
+    sleep 1
+    if ! kill -0 "${VNC_PID}" 2>/dev/null; then
+        echo "⚠ x11vnc failed to start — noVNC will not be available. Last log lines:"
+        tail -n 20 "${LOG_DIR}/x11vnc.log" 2>/dev/null | sed 's/^/    x11vnc| /'
+        return 1
+    fi
+    echo "✓ VNC server started (log: ${LOG_DIR}/x11vnc.log)"
+    return 0
+}
+
+if [ "${VNC_BACKEND}" = "x11vnc" ]; then
+    start_xvfb_x11vnc && DISPLAY_STARTED="x11vnc"
+elif [ "${VNC_BACKEND}" = "tigervnc" ]; then
+    start_tigervnc && DISPLAY_STARTED="tigervnc"
+else
+    # auto: prefer TigerVNC, fall back to the legacy stack.
+    if start_tigervnc; then
+        DISPLAY_STARTED="tigervnc"
+    else
+        echo "Falling back to legacy Xvfb + x11vnc display stack..."
+        start_xvfb_x11vnc && DISPLAY_STARTED="x11vnc"
+    fi
+fi
+
+if [ -z "${DISPLAY_STARTED}" ]; then
+    echo "⚠ No display server could be started — noVNC will not be available."
+fi
+
+# Start window manager on whichever display server came up
 fluxbox >"${LOG_DIR}/fluxbox.log" 2>&1 &
 FLUXBOX_PID=$!
 sleep 1
@@ -90,27 +192,6 @@ if kill -0 "${FLUXBOX_PID}" 2>/dev/null; then
 else
     echo "⚠ fluxbox failed to start (non-critical). Last log lines:"
     tail -n 20 "${LOG_DIR}/fluxbox.log" 2>/dev/null | sed 's/^/    fluxbox| /'
-fi
-
-# Start VNC server (localhost only) and noVNC web interface.
-# x11vnc's -passwd uses DES and silently keeps only the first 8 chars; a longer
-# password would then never authenticate. Since the server is bound to
-# localhost and only reached through websockify, truncate explicitly and warn
-# rather than letting the mismatch fail silently (issue #136).
-if [ "${#VNC_PASSWORD}" -gt 8 ]; then
-    echo "⚠ VNC password longer than 8 chars; x11vnc DES auth uses only the first 8."
-    VNC_PASSWORD="${VNC_PASSWORD:0:8}"
-fi
-echo "Starting VNC server (localhost only)..."
-x11vnc -display :99 -forever -shared -rfbport 5900 -localhost -passwd "${VNC_PASSWORD}" \
-    >"${LOG_DIR}/x11vnc.log" 2>&1 &
-VNC_PID=$!
-sleep 1
-if kill -0 "${VNC_PID}" 2>/dev/null; then
-    echo "✓ VNC server started (log: ${LOG_DIR}/x11vnc.log)"
-else
-    echo "⚠ VNC server failed to start — noVNC will not be available. Last log lines:"
-    tail -n 20 "${LOG_DIR}/x11vnc.log" 2>/dev/null | sed 's/^/    x11vnc| /'
 fi
 
 echo "Starting noVNC on port 6080..."
@@ -124,9 +205,9 @@ else
     tail -n 20 "${LOG_DIR}/websockify.log" 2>/dev/null | sed 's/^/    novnc| /'
 fi
 
-# Display a welcome banner on the Xvfb display so noVNC is not black
+# Display a welcome banner on the virtual display so noVNC is not black
 # before the user triggers the authentication flow (issue #108).
-if [ -x /usr/local/bin/welcome-banner.sh ]; then
+if [ -n "${DISPLAY_STARTED}" ] && [ -x /usr/local/bin/welcome-banner.sh ]; then
     /usr/local/bin/welcome-banner.sh || echo "⚠ Welcome banner failed to start (non-critical)"
 fi
 echo ""

--- a/familylink-playwright/run-standalone.sh
+++ b/familylink-playwright/run-standalone.sh
@@ -48,39 +48,80 @@ if [ ! -S /run/dbus/system_bus_socket ]; then
     dbus-daemon --system --fork 2>/dev/null || echo "⚠ D-Bus not available (non-critical)"
 fi
 
+# The display stack (Xvfb + fluxbox + x11vnc + websockify) is logged to
+# /var/log/familylink so a crash is diagnosable in `docker logs`/that file
+# instead of vanishing into /dev/null (issue #136). Each process is also
+# re-checked after a short delay: kill -0 right after launch only catches an
+# instant failure, and x11vnc's known crash happens later, when a VNC client
+# first connects — so we still tail the log on that path.
+LOG_DIR="/var/log/familylink"
+mkdir -p "${LOG_DIR}"
+
+# Remove a stale X99 socket/lock left by a previous non-graceful stop (e.g.
+# `docker restart`). If they survive, `Xvfb :99` silently refuses to bind and
+# the whole display stack dies invisibly, leaving only uvicorn up (issue #136).
+if [ -e /tmp/.X99-lock ] || [ -e /tmp/.X11-unix/X99 ]; then
+    echo "Cleaning stale X99 lock/socket from a previous run..."
+    rm -f /tmp/.X99-lock /tmp/.X11-unix/X99 2>/dev/null || true
+fi
+
 # Start Xvfb (virtual display)
 # Using 16-bit color depth for better VM compatibility and lower memory usage
 echo "Starting virtual display (Xvfb)..."
-Xvfb :99 -screen 0 1280x1024x16 -ac -nolisten tcp >/dev/null 2>&1 &
+Xvfb :99 -screen 0 1280x1024x16 -ac -nolisten tcp >"${LOG_DIR}/xvfb.log" 2>&1 &
+XVFB_PID=$!
 export DISPLAY=:99
 
-# Wait for Xvfb to start
+# Wait for Xvfb to start, then confirm it is actually up
 sleep 2
-echo "✓ Virtual display started on :99"
+if kill -0 "${XVFB_PID}" 2>/dev/null; then
+    echo "✓ Virtual display started on :99"
+else
+    echo "⚠ Xvfb failed to start — VNC will be unavailable. Last log lines:"
+    tail -n 20 "${LOG_DIR}/xvfb.log" 2>/dev/null | sed 's/^/    xvfb| /'
+fi
 
 # Start window manager
-fluxbox >/dev/null 2>&1 &
-echo "✓ Window manager (fluxbox) started"
+fluxbox >"${LOG_DIR}/fluxbox.log" 2>&1 &
+FLUXBOX_PID=$!
+sleep 1
+if kill -0 "${FLUXBOX_PID}" 2>/dev/null; then
+    echo "✓ Window manager (fluxbox) started"
+else
+    echo "⚠ fluxbox failed to start (non-critical). Last log lines:"
+    tail -n 20 "${LOG_DIR}/fluxbox.log" 2>/dev/null | sed 's/^/    fluxbox| /'
+fi
 
-# Start VNC server (localhost only) and noVNC web interface
+# Start VNC server (localhost only) and noVNC web interface.
+# x11vnc's -passwd uses DES and silently keeps only the first 8 chars; a longer
+# password would then never authenticate. Since the server is bound to
+# localhost and only reached through websockify, truncate explicitly and warn
+# rather than letting the mismatch fail silently (issue #136).
+if [ "${#VNC_PASSWORD}" -gt 8 ]; then
+    echo "⚠ VNC password longer than 8 chars; x11vnc DES auth uses only the first 8."
+    VNC_PASSWORD="${VNC_PASSWORD:0:8}"
+fi
 echo "Starting VNC server (localhost only)..."
-x11vnc -display :99 -forever -shared -rfbport 5900 -localhost -passwd "${VNC_PASSWORD}" >/dev/null 2>&1 &
+x11vnc -display :99 -forever -shared -rfbport 5900 -localhost -passwd "${VNC_PASSWORD}" \
+    >"${LOG_DIR}/x11vnc.log" 2>&1 &
 VNC_PID=$!
 sleep 1
 if kill -0 "${VNC_PID}" 2>/dev/null; then
-    echo "✓ VNC server started"
+    echo "✓ VNC server started (log: ${LOG_DIR}/x11vnc.log)"
 else
-    echo "⚠ VNC server failed to start — noVNC will not be available"
+    echo "⚠ VNC server failed to start — noVNC will not be available. Last log lines:"
+    tail -n 20 "${LOG_DIR}/x11vnc.log" 2>/dev/null | sed 's/^/    x11vnc| /'
 fi
 
 echo "Starting noVNC on port 6080..."
-websockify --web=/usr/share/novnc 6080 localhost:5900 >/dev/null 2>&1 &
+websockify --web=/usr/share/novnc 6080 localhost:5900 >"${LOG_DIR}/websockify.log" 2>&1 &
 NOVNC_PID=$!
 sleep 1
 if kill -0 "${NOVNC_PID}" 2>/dev/null; then
     echo "✓ noVNC started"
 else
-    echo "⚠ noVNC (websockify) failed to start on port 6080"
+    echo "⚠ noVNC (websockify) failed to start on port 6080. Last log lines:"
+    tail -n 20 "${LOG_DIR}/websockify.log" 2>/dev/null | sed 's/^/    novnc| /'
 fi
 
 # Display a welcome banner on the Xvfb display so noVNC is not black


### PR DESCRIPTION
Fixes #136.

The auth container's noVNC hung on **"Connecting…" forever**, 100% of the time. @wookash did an exceptional job diagnosing it with `strace`: `x11vnc` 0.9.16 (2019) tears down its own X connection the instant a VNC client connects, and because the whole display stack was launched with output to `/dev/null` and no real liveness check, the failure was completely silent — the container stayed "healthy" on uvicorn/8099 while VNC was dead.

This PR ships in two layers.

## 1. Make silent failures visible + fix the restart bug (low-risk)

- **Logging & liveness.** The standalone container now logs each display process to `/var/log/familylink/<proc>.log` instead of `/dev/null`, and re-checks it after launch, dumping the last log lines on failure. The add-on entrypoint (already on journald) gains the same Xvfb/fluxbox/x11vnc checks.
- **Stale X99 cleanup.** A non-graceful stop (`docker restart`) left `/tmp/.X11-unix/X99` + `/tmp/.X99-lock` behind, which made `Xvfb :99` silently refuse to bind next start and took the display stack down — only uvicorn came back, so the container reported healthy. Both are now removed before Xvfb/Xvnc starts. This is the secondary bug @wookash also reported.
- **VNC password.** `-passwd` uses DES and silently keeps only the first 8 chars, so the 10-char default (`familylink`) never matched cleanly. It's now truncated explicitly with a warning, and the web UI's auto-connect URL embeds the same 8-char value so client and server agree.

## 2. Replace x11vnc with TigerVNC as the default backend (the real fix)

Rather than chase an x11vnc build compatible with bookworm's X libs, the container now prefers **TigerVNC's `Xvnc`** — an X server that speaks RFB/VNC natively, so there's no separate Xvfb and no x11vnc screen-scraper. **The exact component that crashed is gone.**

- `start_tigervnc()` builds a VNC-auth password file with `vncpasswd -f` (filter mode — deterministic, no interactive prompts) or `-SecurityTypes None`, then starts `Xvnc` on `:99` / port `5900`, localhost-only.
- `start_xvfb_x11vnc()` is kept as an **automatic fallback**, so no environment loses VNC if `Xvnc` is missing or fails.
- Dispatch is `auto` (TigerVNC → fallback) by default; `FAMILYLINK_VNC_BACKEND=tigervnc|x11vnc` forces a backend.
- `tigervnc-standalone-server` added to both Dockerfiles (x11vnc kept for the fallback). Add-on `config.json` → `1.8.0`, Dockerfile version labels synced.

## Testing status ⚠️

There is **no Docker in my dev environment**, so I could not build/run the container end-to-end. What I did verify:

- `bash -n` on both entrypoints, plus a stubbed-binary smoke test of the full control flow (backend selection, password truncation to 8, `vncpasswd -f` path, `Xvnc`/`x11vnc` argument construction, and the fallback path) — all branches produce well-formed commands.
- All `Xvnc` flags (`-localhost`, `-rfbport`, `-SecurityTypes None|VncAuth`, `-rfbauth`, `-desktop`, `-geometry`, `-depth`) confirmed against the TigerVNC man pages.

The **connect-time crash itself only reproduces on the reporter's real environment** (NAS, x86_64 Debian), which is why this is proposed for a **pre-release** so @wookash can validate on the machine where the bug actually occurs before it goes to `latest`.