### PR TITLE
Fix #140: read back the school time "today only" override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **School time switch no longer springs back ON after being turned off (issue #140).** Turning school time off in Home Assistant posted a correct `action=1` daily override, but nothing ever read it back, so the next refresh returned the switch to ON and it looked like Home Assistant and the Family Link app had drifted apart. The today-effective override resolution added for bedtime in #113 could not cover school time: both override types share `item[2] == 9`, but bedtime ends with a `CAEQxx` day-code **string** while school time carries a `[weekday, rule_uuid]` **list**, so the bedtime reader's `startswith("CAEQ")` filter structurally never matched one. `async_get_time_limit` now resolves school time overrides through a dedicated parser (most recent by timestamp wins, since Google appends rather than replaces) and returns `school_time_enabled_today`, which the coordinator prefers over the `appliedTimeLimits` value, exactly mirroring the bedtime path. Reported by @Piepke82 (#140).
+- **School time no longer appears to "turn itself on" at the start of the school window (issue #140).** `appliedTimeLimits` sets its school time flag as soon as a window exists for today, which means *"a school time window is **scheduled** today"*, not *"school time is enabled"*. Used alone it flipped the switch to ON at the window's start hour regardless of any override. That value is now kept separately as `school_time_scheduled_today` and no longer decides the switch state on its own.
+
+### Added
+- **Diagnostic attributes on the school time switch (issue #140).** The switch now exposes `school_time_enabled_weekly` (the weekly policy toggle) and `school_time_scheduled_today` (whether today has a school time window at all) alongside its own today-effective state. A "today only" override legitimately makes these disagree, since the weekly toggle in the Family Link app stays ON when only today is turned off, so showing the three together makes an apparent desync self-explanatory instead of looking like a bug.
+
+### Changed
+- **Failure to read existing school time overrides is now logged as a warning.** `_async_list_schooltime_overrides_today` previously swallowed fetch failures at DEBUG level and returned an empty list, silently skipping the DELETE-before-CREATE cleanup and allowing stacked, conflicting overrides to accumulate on the same day. The fetch/unwrap step is now shared with the state reader (`_async_fetch_time_limit_data`) and logs at WARNING when it cannot read them.
+
+---
+
 ## Add-on / auth container [1.8.0] - 2026-07-24
 
 ### Fixed

--- a/GOOGLE_FAMILY_LINK_API_ANALYSIS.md
+++ b/GOOGLE_FAMILY_LINK_API_ANALYSIS.md
@@ -122,6 +122,19 @@ Where `[start_h, …]` and `[end_h, …]` are today's weekly bedtime hours.
 2. Then `POST /people/{childId}/timeLimitOverrides:batchCreate` with the same body as above but `action=1`.
 
 This DELETE → CREATE pattern mirrors what the web app emits when unchecking the "Today" toggle and avoids leaving stacked, conflicting overrides on the same day.
+**Reading the school time override back (today-effective state), issue #140.** Exactly as for bedtime above, the daily override is echoed in the `GET .../timeLimit` response and is the only reliable source for "is school time on today?". The shape differs in one decisive way:
+
+```
+[override_uuid, ts, 9, '', '', None,None,None, profile_id, None,None,None,
+ [action, [startH,startM], [endH,endM], null, [iso_weekday, rule_uuid]]]
+```
+
+- Both bedtime and school time overrides use `item[2] == 9`. What tells them apart is the **payload shape**: bedtime ends with a `CAEQxx` **day-code string** at `payload[3]` (4 elements), school time carries a `[iso_weekday, rule_uuid]` **list** at `payload[4]` (5 elements).
+- Consequence: a reader that filters on `payload[3].startswith("CAEQ")`, as the bedtime resolver does, can **never** match a school time override. This is why the #113 today-effective fix did not extend to school time and had to be implemented separately (`_parse_schooltime_overrides`).
+- Resolution rule is identical: among all overrides matching today's `iso_weekday` **and** the school time `rule_uuid`, the one with the largest `item[1]` timestamp wins. `async_get_time_limit` returns this as `school_time_enabled_today`, and the coordinator prefers it over the `appliedTimeLimits`-derived value.
+
+> **`appliedTimeLimits` answers a different question.** Its window scan sets `schooltime_enabled_today` as soon as a school time window exists for today in the weekly policy. That means *"a school time window is **scheduled** today"*, **not** *"school time is enabled"*. On its own it therefore springs back to ON after a "today only" OFF override, and appears to "turn itself on" at the window's start hour. The integration keeps it under the separate name `school_time_scheduled_today` (exposed as a switch attribute) precisely to keep the two questions apart.
+
 
 ### Day Codes (CAEQ* - for daily limit)
 The `day_code` in the daily limit payload encodes the day of the week. **You MUST use the code corresponding to the current day** for the change to take effect immediately.

--- a/custom_components/familylink/client/api.py
+++ b/custom_components/familylink/client/api.py
@@ -1967,15 +1967,64 @@ class FamilyLinkClient:
 			_LOGGER.error("Unexpected error applying school time override: %s", err)
 			return False
 
-	async def _async_list_schooltime_overrides_today(
-		self, account_id: str, rule_id: str, weekday: int
-	) -> list[str]:
-		"""Return UUIDs of existing schooltime overrides for today.
+	@staticmethod
+	def _parse_schooltime_overrides(
+		data: Any, rule_id: str, weekday: int
+	) -> list[tuple[str, int, int]]:
+		"""Extract today's schooltime overrides from an unwrapped timeLimit payload.
 
-		Reads the time limit endpoint and extracts override entries whose
-		payload references the schooltime rule and the current weekday. Used
-		before posting a new override to avoid stacking.
+		Returns a list of ``(uuid, timestamp_ms, action)`` tuples for every
+		type-9 override that references ``rule_id`` on ``weekday``
+		(action 2 = school time ON, 1 = OFF).
+
+		``data`` is the already-unwrapped ``response_data[1]`` of a
+		``people/{id}/timeLimit`` response. Override entries look like:
+		  [uuid, ts, 9, "", "", null, null, null, account_id, null, null, null,
+		   [action, [start_h, m], [end_h, m], null, [weekday, rule_uuid]]]
+
+		Unlike bedtime overrides, which are keyed by an opaque ``CAEQxx`` day
+		code (see `_DAY_CODES`), school time overrides carry an explicit
+		``[weekday, rule_uuid]`` reference at ``payload[4]``. That difference is
+		why the bedtime reader (which filters on ``startswith("CAEQ")``) can
+		never match a school time override, and why issue #113's today-effective
+		fix had to be duplicated here rather than reused as-is (issue #140).
 		"""
+		matches: list[tuple[str, int, int]] = []
+		if not isinstance(data, list):
+			return matches
+
+		for element in data:
+			if not isinstance(element, list):
+				continue
+			for item in element:
+				if not isinstance(item, list) or len(item) < 13:
+					continue
+				if not isinstance(item[0], str):
+					continue
+				if item[2] != 9:
+					continue
+				payload = item[12]
+				if not isinstance(payload, list) or len(payload) < 5:
+					continue
+				rule_ref = payload[4]
+				if not isinstance(rule_ref, list) or len(rule_ref) < 2:
+					continue
+				if rule_ref[0] != weekday or rule_ref[1] != rule_id:
+					continue
+				action = payload[0]
+				if action not in (1, 2):
+					continue
+				# Override timestamp at item[1] (epoch ms as a string).
+				try:
+					ts = int(item[1])
+				except (TypeError, ValueError):
+					ts = -1
+				matches.append((item[0], ts, action))
+
+		return matches
+
+	async def _async_fetch_time_limit_data(self, account_id: str) -> Any | None:
+		"""Fetch and unwrap the raw timeLimit payload, or None on failure."""
 		try:
 			session = await self._get_session()
 			cookie_header = self._get_cookie_header()
@@ -1995,44 +2044,42 @@ class FamilyLinkClient:
 				},
 			) as response:
 				if response.status != 200:
-					_LOGGER.debug(
-						"Could not fetch overrides (HTTP %s) — skipping cleanup",
+					_LOGGER.warning(
+						"Could not fetch time limit overrides (HTTP %s)",
 						response.status,
 					)
-					return []
-				data = await response.json()
+					return None
+				response_data = await response.json()
 		except Exception as err:
-			_LOGGER.debug("Failed to list school time overrides: %s", err)
+			_LOGGER.warning("Failed to fetch time limit overrides: %s", err)
+			return None
+
+		# Unwrap the response: [[metadata], [real_data]] -> real_data
+		if not isinstance(response_data, list) or len(response_data) < 2:
+			return None
+		return response_data[1]
+
+	async def _async_list_schooltime_overrides_today(
+		self, account_id: str, rule_id: str, weekday: int
+	) -> list[str]:
+		"""Return UUIDs of existing schooltime overrides for today.
+
+		Reads the time limit endpoint and extracts override entries whose
+		payload references the schooltime rule and the current weekday. Used
+		before posting a new override to avoid stacking.
+		"""
+		data = await self._async_fetch_time_limit_data(account_id)
+		if data is None:
+			_LOGGER.warning(
+				"Skipping school time override cleanup: could not read existing "
+				"overrides; a stale override may keep arbitrating today"
+			)
 			return []
 
-		# Unwrapped structure: data[1] holds the payload. Override entries
-		# look like:
-		# [uuid, ts, 9, "", "", null, null, null, account_id, null, null, null,
-		#  [action, [start_h, m], [end_h, m], null, [weekday, rule_uuid]]]
-		matches: list[str] = []
-		if not isinstance(data, list) or len(data) < 2:
-			return matches
-		inner = data[1]
-		if not isinstance(inner, list):
-			return matches
-
-		for element in inner:
-			if not isinstance(element, list):
-				continue
-			for item in element:
-				if not isinstance(item, list) or len(item) < 13:
-					continue
-				if not isinstance(item[0], str):
-					continue
-				payload = item[12]
-				if not isinstance(payload, list) or len(payload) < 5:
-					continue
-				rule_ref = payload[4]
-				if not isinstance(rule_ref, list) or len(rule_ref) < 2:
-					continue
-				if rule_ref[0] != weekday or rule_ref[1] != rule_id:
-					continue
-				matches.append(item[0])
+		matches = [
+			uuid for uuid, _ts, _action
+			in self._parse_schooltime_overrides(data, rule_id, weekday)
+		]
 
 		if matches:
 			_LOGGER.debug(
@@ -2582,6 +2629,7 @@ class FamilyLinkClient:
 						"bedtime_enabled": False,
 						"school_time_enabled": False,
 						"bedtime_enabled_today": None,
+						"school_time_enabled_today": None,
 						"bedtime_schedule": [],
 						"school_time_schedule": [],
 						"bedtime_rule_id": None,
@@ -2598,6 +2646,7 @@ class FamilyLinkClient:
 						"bedtime_enabled": False,
 						"school_time_enabled": False,
 						"bedtime_enabled_today": None,
+						"school_time_enabled_today": None,
 						"bedtime_schedule": [],
 						"school_time_schedule": [],
 						"bedtime_rule_id": None,
@@ -2780,10 +2829,44 @@ class FamilyLinkClient:
 							f"(weekly was {bedtime_enabled})"
 						)
 
+				# Today-effective SCHOOL TIME state (issue #140).
+				#
+				# Same mechanism as bedtime above, but school time overrides are
+				# shaped differently: they carry an explicit [weekday, rule_uuid]
+				# reference instead of a CAEQxx day code, so the bedtime loop
+				# above can never match them. Without this, turning school time
+				# off in HA posted a valid action=1 override that was never read
+				# back, and the switch kept deriving its state from the weekly
+				# window in appliedTimeLimits and sprang back to ON on the next
+				# refresh.
+				#
+				# Overrides ACCUMULATE (Google appends rather than replaces), so
+				# the effective one is the most recent by timestamp, exactly as
+				# for bedtime.
+				school_time_enabled_today = school_time_enabled
+				if schooltime_rule_id:
+					weekday = dt_util.now().isoweekday()
+					overrides = self._parse_schooltime_overrides(
+						data, schooltime_rule_id, weekday
+					)
+					if overrides:
+						_uuid, latest_ts, latest_action = max(
+							overrides, key=lambda o: o[1]
+						)
+						school_time_enabled_today = (latest_action == 2)
+						_LOGGER.debug(
+							f"Most recent school time override for today "
+							f"(weekday={weekday}, ts={latest_ts}): "
+							f"action={latest_action} -> "
+							f"school_time_enabled_today={school_time_enabled_today} "
+							f"(weekly was {school_time_enabled})"
+						)
+
 				_LOGGER.info(
 					f"Time limit rules: bedtime_enabled={bedtime_enabled} (rule_id={bedtime_rule_id}, {len(bedtime_schedule)} schedules), "
 					f"bedtime_enabled_today={bedtime_enabled_today}, "
-					f"school_time_enabled={school_time_enabled} (rule_id={schooltime_rule_id}, {len(school_time_schedule)} schedules)"
+					f"school_time_enabled={school_time_enabled} (rule_id={schooltime_rule_id}, {len(school_time_schedule)} schedules), "
+					f"school_time_enabled_today={school_time_enabled_today}"
 				)
 
 				return {
@@ -2793,6 +2876,8 @@ class FamilyLinkClient:
 					# override if one exists for today (issue #113). Falls back to
 					# the weekly value when no override is posted for today.
 					"bedtime_enabled_today": bedtime_enabled_today,
+					# Same, for school time (issue #140).
+					"school_time_enabled_today": school_time_enabled_today,
 					"bedtime_schedule": bedtime_schedule,
 					"school_time_schedule": school_time_schedule,
 					"bedtime_rule_id": bedtime_rule_id,

--- a/custom_components/familylink/coordinator.py
+++ b/custom_components/familylink/coordinator.py
@@ -220,18 +220,21 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 			# "Only today" override Google actually applies — and takes
 			# precedence over the appliedTimeLimits heuristic below.
 			bedtime_enabled_today_from_rules = None
+			school_time_enabled_today_from_rules = None
 
 			try:
 				time_limit_config = await self.client.async_get_time_limit(account_id=child_id)
 				bedtime_enabled = time_limit_config.get("bedtime_enabled")
 				school_time_enabled = time_limit_config.get("school_time_enabled")
 				bedtime_enabled_today_from_rules = time_limit_config.get("bedtime_enabled_today")
+				school_time_enabled_today_from_rules = time_limit_config.get("school_time_enabled_today")
 				bedtime_schedule = time_limit_config.get("bedtime_schedule")
 				school_time_schedule = time_limit_config.get("school_time_schedule")
 				_LOGGER.debug(
 					f"Fetched time limit config for {child_name}: "
 					f"bedtime={bedtime_enabled}, bedtime_today={bedtime_enabled_today_from_rules}, "
-					f"school_time={school_time_enabled}"
+					f"school_time={school_time_enabled}, "
+					f"school_time_today={school_time_enabled_today_from_rules}"
 				)
 			except SessionExpiredError:
 				raise  # Re-raise to trigger auth notification
@@ -244,6 +247,7 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 							bedtime_enabled = cached_child.get("bedtime_enabled")
 							school_time_enabled = cached_child.get("school_time_enabled")
 							bedtime_enabled_today_from_rules = cached_child.get("bedtime_enabled_today")
+							school_time_enabled_today_from_rules = cached_child.get("school_time_enabled_today")
 							bedtime_schedule = cached_child.get("bedtime_schedule")
 							school_time_schedule = cached_child.get("school_time_schedule")
 							_LOGGER.debug(f"Using cached time limit config for {child_name}")
@@ -292,6 +296,20 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 			# "Only today" OFF override leaves no enabled window to detect).
 			if bedtime_enabled_today_from_rules is not None:
 				bedtime_enabled_today = bedtime_enabled_today_from_rules
+
+			# Same for school time (issue #140). School time overrides are keyed
+			# by [weekday, rule_uuid] rather than a day code, so they are read by
+			# a dedicated parser, but the precedence rule is identical: an
+			# explicit override for today beats the appliedTimeLimits window
+			# scan, which only tells us a school time window is SCHEDULED today,
+			# not whether it is actually enabled.
+			#
+			# The raw appliedTimeLimits value is kept as
+			# school_time_scheduled_today and exposed as a switch attribute, so
+			# a "scheduled but overridden off" day is visible without a debug log.
+			school_time_scheduled_today = schooltime_enabled_today
+			if school_time_enabled_today_from_rules is not None:
+				schooltime_enabled_today = school_time_enabled_today_from_rules
 
 			# Update device cache with real lock states from API
 			current_time = time.time()
@@ -409,6 +427,9 @@ class FamilyLinkDataUpdateCoordinator(DataUpdateCoordinator):
 				# weekly-only revisions above.
 				"bedtime_enabled_today": bedtime_enabled_today,
 				"school_time_enabled_today": schooltime_enabled_today,
+				# Whether a school time window exists in today's weekly policy,
+				# independent of any "today only" override (issue #140).
+				"school_time_scheduled_today": school_time_scheduled_today,
 				"bedtime_schedule": bedtime_schedule,
 				"school_time_schedule": school_time_schedule,
 				"daily_limit_enabled": daily_limit_enabled,

--- a/custom_components/familylink/switch.py
+++ b/custom_components/familylink/switch.py
@@ -427,6 +427,29 @@ class FamilyLinkSchoolTimeSwitch(CoordinatorEntity, SwitchEntity):
 		return self.coordinator.last_update_success
 
 	@property
+	def extra_state_attributes(self) -> dict[str, Any]:
+		"""Expose why the switch is in its current state (issue #140).
+
+		`school_time_scheduled_today` says a school time window exists in the
+		weekly policy for today; `school_time_enabled` is the weekly toggle.
+		The switch itself shows the today-effective state, which a "today only"
+		override can flip away from both, so surfacing the three side by side
+		makes an apparent desync self-explanatory.
+		"""
+		attributes: dict[str, Any] = {}
+		if self.coordinator.data and "children_data" in self.coordinator.data:
+			for child_data in self.coordinator.data["children_data"]:
+				if child_data["child_id"] == self._child_id:
+					attributes["school_time_enabled_weekly"] = child_data.get(
+						"school_time_enabled"
+					)
+					attributes["school_time_scheduled_today"] = child_data.get(
+						"school_time_scheduled_today"
+					)
+					break
+		return attributes
+
+	@property
 	def icon(self) -> str:
 		"""Return the icon for the switch."""
 		return "mdi:school" if self.is_on else "mdi:school-outline"


### PR DESCRIPTION
Fixes #140.

## The report

@Piepke82 saw the School Time switch showing ON in Home Assistant while the Family Link app showed OFF, apparently switching itself on at 08:00 every morning, and turning it off in HA changed nothing on Google's side.

Two separate problems, plus one thing that turned out to be expected behavior.

## 1. The "today only" OFF override was written but never read back

`async_disable_school_time` posts a correct `action=1` daily override, and that part works. Nothing ever read it back, so the next coordinator refresh recomputed the switch from the weekly schedule and returned it to ON.

The reason this slipped through is worth recording. We fixed exactly this for bedtime in #113, but that fix could not extend to school time:

| | bedtime override | school time override |
|---|---|---|
| type code | `item[2] == 9` | `item[2] == 9` |
| payload | `[action, [h,m], [h,m], "CAEQxx"]` | `[action, [h,m], [h,m], null, [weekday, rule_uuid]]` |
| keyed by | opaque day-code **string** | `[weekday, rule_uuid]` **list** |

The bedtime resolver selects overrides with `payload[3].startswith("CAEQ")`, which structurally can never match a school time override. So school time silently kept falling through to the weaker `appliedTimeLimits` path.

This PR adds `_parse_schooltime_overrides`, returning `(uuid, ts, action)` for every type-9 override matching today's weekday and the school time rule. Most recent by timestamp wins, since Google appends overrides rather than replacing them (the same accumulation behavior documented in #113), which also makes it immune to response ordering. `async_get_time_limit` now returns `school_time_enabled_today` and the coordinator prefers it over the `appliedTimeLimits` value, mirroring the bedtime path exactly.

## 2. "It switches on automatically at 08:00"

Same root cause, different symptom. The `appliedTimeLimits` flag goes true as soon as a school time window exists for today, which answers *"is a school time window **scheduled** today?"* and not *"is school time enabled?"*. On its own it flipped the switch ON at the window's start hour regardless of any override.

That value is now kept separately as `school_time_scheduled_today` and no longer decides the switch state by itself.

## 3. The app showing OFF is expected, not a bug

Worth stating explicitly since it will come up again: the switch changes school time **for today only**, exactly like the app's "Today" toggle, and deliberately leaves the weekly policy untouched (`_async_apply_school_time_today`). The weekly toggle in the Family Link app legitimately stays as it was.

To stop that reading as a desync, the switch now exposes two attributes:

- `school_time_enabled_weekly`: the weekly policy toggle, i.e. what the app shows
- `school_time_scheduled_today`: whether today has a school time window at all

When these disagree with the switch, a "today only" override is in effect and everything is working as intended.

## Also in here

`_async_list_schooltime_overrides_today` swallowed fetch failures at DEBUG and returned an empty list, silently skipping the DELETE-before-CREATE cleanup and letting conflicting overrides stack up on the same day. The fetch/unwrap step is now shared with the state reader (`_async_fetch_time_limit_data`) and logs at WARNING when it cannot read them.

## Verification

There is no test runner in this repo, so the parser was extracted from the source and exercised offline:

- **13 unit cases** on the parser: OFF override found; most-recent-wins with timestamps out of order; wrong weekday and wrong rule ignored; bedtime overrides not captured; type-10 (bonus) ignored; malformed rows tolerated without raising; non-numeric timestamp degrading to `-1`.
- **Cleanup regression**: the pre-fix matching logic, taken verbatim from `main`, and the new parser select the **same override UUIDs** across four payloads, so the DELETE-before-CREATE path is unchanged.
- **End-to-end scenario** replaying the switch's `is_on` plus the coordinator precedence: ON at rest, OFF after turn-off, **still OFF after the next refresh** (the exact moment the bug used to strike), ON regaining control when newer, order-independent, and no ON flip at the window's start hour.
- Pyflakes shows no new warnings against the baseline; CRLF line endings and tab indentation preserved.

Also documented the school time override shape and the scheduled-vs-enabled distinction in `GOOGLE_FAMILY_LINK_API_ANALYSIS.md`, since that asymmetry is what made this bug survive #113.

## Caveat before merging

The parser was validated against **synthetic payloads only**. It has not yet seen a live Google response, so the assumed override shape, which comes from the existing write path and the documented capture, should ideally be confirmed on a real account before this goes out as stable.

Note this needs a **full Home Assistant restart** to take effect, not a config entry reload.
