### PR TITLE
addon 1.8.1: pull the prebuilt GHCR image instead of building locally

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -38,6 +38,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Read add-on version from config.json
+        id: addon_version
+        run: echo "version=$(jq -r .version familylink-playwright/config.json)" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata for addon image (tags, labels)
         id: meta-addon
         uses: docker/metadata-action@v5
@@ -50,6 +54,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ steps.addon_version.outputs.version }}
 
       - name: Extract metadata for standalone image (tags, labels)
         id: meta-standalone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## Add-on / auth container [1.8.1] - 2026-08-21
+
+### Changed
+- **Add-on installs now pull the prebuilt multi-arch image from GHCR instead of compiling locally.** `config.json` declares `image: ghcr.io/noiwid/familylink-auth` and CI tags the published image with the add-on version, so installing or updating the add-on downloads in seconds instead of building Chromium and Playwright on the Home Assistant machine. Local builds remain available as a fallback.
+
+---
+
 ## [1.2.13] - 2026-08-21
 
 ### Fixed

--- a/familylink-playwright/CHANGELOG.md
+++ b/familylink-playwright/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Google Family Link Auth Add-on will be documented in this file.
 
+## [1.8.1] - 2026-08-21
+
+### Changed
+- **Add-on installs now pull the prebuilt multi-arch image from GHCR instead of compiling locally.** Installing previously built the whole image (Chromium and Playwright included) on the Home Assistant machine, which took a long time on low-power hardware. The add-on now declares `image: ghcr.io/noiwid/familylink-auth`, and CI publishes that image tagged with the add-on version on every push, so the Supervisor downloads it in seconds. Local builds keep working as a fallback (`build.json` is unchanged).
+
 ## [1.8.0] - 2026-07-24
 
 ### Fixed

--- a/familylink-playwright/DOCS.md
+++ b/familylink-playwright/DOCS.md
@@ -11,7 +11,7 @@ After a successful login, the add-on extracts the Google session cookies, encryp
 ## Installation
 
 1. Go to **Settings > Add-ons > Add-on Store**, open the three-dot menu, choose **Repositories**, and add `https://github.com/noiwid/HAFamilyLink`.
-2. Install **Google Family Link Auth**. The image is built locally on your machine, so the install takes several minutes.
+2. Install **Google Family Link Auth**. The prebuilt image is downloaded from GHCR, so the install only takes a moment.
 3. Optionally adjust the options in the **Configuration** tab (see [Configuration](#configuration)).
 4. Start the add-on. Enabling **Start on boot** and **Watchdog** is recommended.
 

--- a/familylink-playwright/config.json
+++ b/familylink-playwright/config.json
@@ -1,9 +1,10 @@
 {
   "name": "Google Family Link Auth",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "slug": "familylink-playwright",
   "description": "Authentication service for Google Family Link integration using browser automation",
   "url": "https://github.com/noiwid/HAFamilyLink",
+  "image": "ghcr.io/noiwid/familylink-auth",
   "arch": ["amd64", "aarch64"],
   "startup": "application",
   "boot": "auto",


### PR DESCRIPTION
Add-on 1.8.1: installs pull the prebuilt multi-arch image from GHCR instead of compiling Chromium and Playwright on the Home Assistant machine.

## Why

CI already publishes a multi-arch (amd64/arm64) add-on image on every push to main, but the Supervisor install flow never consumed it: `config.json` had no `image` key, and the published image was only tagged from git tags (integration versions like `1.2.13`), never with the add-on version that the Supervisor pulls (`{image}:{config.json version}`).

## What

- `config.json`: declares `"image": "ghcr.io/noiwid/familylink-auth"` and bumps the add-on to **1.8.1**. The image is a multi-arch manifest, so the Supervisor resolves amd64/aarch64 automatically.
- CI: a new step reads the add-on version from `config.json` (`jq -r .version`) and adds it as an image tag, so `familylink-auth:1.8.1` (and any future version) always exists when the Supervisor asks for it.
- `build.json` unchanged: local builds keep working as a fallback.
- DOCS.md install step and both changelogs updated.

Verified: the GHCR package accepts anonymous pulls (tested `latest`, `standalone` and `1.2.13` manifests with a pull-scope token), which is what the Supervisor does.

## Merge ordering note

The 1.8.1 image tag is published by the CI run triggered by this merge. A user refreshing the add-on store within the first minutes after the merge could try to pull the tag before the build finishes; the window is short (the build is cached) and self-heals on retry.
