### PR TITLE
Add set_update_interval action (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- **`set_update_interval` action (issue #156)** - An automation can now change the polling interval at runtime, for example every 10 minutes during bedtime and every minute during the day, to reduce the number of requests to Google when nothing is expected to change. The new interval applies immediately and lasts until the next reload or restart, after which the value from the integration options applies again; it is deliberately not written to the options. Requested by @beamer2k23.
+
+### Fixed
+- **`ring_device` is now unregistered when the last config entry is unloaded** - It was the only action left behind after an unload, so it survived with a dead coordinator reference until the next restart.
+
+---
+
+## [1.2.15-rc2] - 2026-09-02
+
+### Added
 - **Allowed calls and texts select entity (PR #150, by @mdo77)** - Each child gets `select.<child>_allowed_calls_texts` to choose who can call and text them: **Anyone**, **Only contacts I add** or **Contacts I add & limited groups**. The level is read from Google's `trustedcontacts` endpoint by the coordinator with the other per-child data (cache fallback and session-expiry handling included) and written back through `trustedcontacts:update`. An account where the setting was never touched reports level 0, shown as Anyone. Endpoint shape confirmed on a live capture.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ GPS entities are only created when location tracking is enabled in the integrati
 | `familylink.enable_school_time` / `familylink.disable_school_time` | Toggle school time |
 | `familylink.refresh_location` | Force a fresh GPS fix (uses more battery than the regular polling) |
 | `familylink.ring_device` | Make a device ring so it can be found |
+| `familylink.set_update_interval` | Change the polling interval until the next restart (e.g. slower at night) |
 
 Targeting: every service accepts an optional `entity_id` or explicit `child_id` / `device_id`. Without a target, the app and location services apply to **all** supervised children, while the time services fall back to the **first** supervised child. Full field reference, defaults and examples: **[SERVICES.md](SERVICES.md)**.
 

--- a/SERVICES.md
+++ b/SERVICES.md
@@ -257,6 +257,23 @@ data:
   entity_id: switch.pixel_7
 ```
 
+## Polling
+
+### familylink.set_update_interval
+
+Changes how often the integration polls Google. The new interval applies immediately and lasts until the next reload or restart, after which the value set in the integration options applies again. It is not saved to the options on purpose, so an automation can lengthen the interval at bedtime and shorten it in the morning without changing the configured value.
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `seconds` | integer | yes | - | Polling interval in seconds, 30 to 3600 |
+
+```yaml
+# Poll every 10 minutes at night
+action: familylink.set_update_interval
+data:
+  seconds: 600
+```
+
 ## Finding package names
 
 | Source | Where the package name is |

--- a/custom_components/familylink/__init__.py
+++ b/custom_components/familylink/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -14,6 +15,8 @@ import voluptuous as vol
 from .const import (
 	DOMAIN,
 	LOGGER_NAME,
+	MAX_UPDATE_INTERVAL,
+	MIN_UPDATE_INTERVAL,
 	SERVICE_ADD_TIME_BONUS,
 	SERVICE_BLOCK_APP,
 	SERVICE_BLOCK_DEVICE_FOR_SCHOOL,
@@ -26,6 +29,7 @@ from .const import (
 	SERVICE_SET_APP_DAILY_LIMIT,
 	SERVICE_SET_BEDTIME,
 	SERVICE_SET_DAILY_LIMIT,
+	SERVICE_SET_UPDATE_INTERVAL,
 	SERVICE_REFRESH_LOCATION,
 	SERVICE_RING_DEVICE,
 	SERVICE_UNBLOCK_ALL_APPS,
@@ -132,6 +136,12 @@ SCHEMA_RING_DEVICE = vol.Schema({
 	vol.Optional("entity_id"): cv.entity_id,
 	vol.Optional("device_id"): cv.string,
 	vol.Optional("child_id"): cv.string,
+})
+
+SCHEMA_SET_UPDATE_INTERVAL = vol.Schema({
+	vol.Required("seconds"): vol.All(
+		vol.Coerce(int), vol.Range(min=MIN_UPDATE_INTERVAL, max=MAX_UPDATE_INTERVAL)
+	),
 })
 
 
@@ -784,6 +794,30 @@ async def async_setup_services(hass: HomeAssistant, coordinator: FamilyLinkDataU
 		schema=SCHEMA_SET_APP_DAILY_LIMIT,
 	)
 
+	async def handle_set_update_interval(call: ServiceCall) -> None:
+		"""Handle set_update_interval - change the polling interval at runtime (issue #156).
+
+		The new interval applies to every coordinator of the integration and lasts
+		until the next restart or reload, after which the value from the options
+		takes over again. Not persisted on purpose: an automation that lengthens
+		the interval at bedtime and shortens it in the morning must not leave the
+		configured value changed behind the user's back.
+		"""
+		seconds = call.data["seconds"]
+		interval = timedelta(seconds=seconds)
+		coordinators = [
+			c for c in hass.data.get(DOMAIN, {}).values()
+			if isinstance(c, FamilyLinkDataUpdateCoordinator)
+		]
+		for coord in coordinators:
+			previous = coord.update_interval
+			coord.update_interval = interval
+			_LOGGER.info(
+				f"Service called: set_update_interval - polling every {seconds}s "
+				f"(was {int(previous.total_seconds()) if previous else '?'}s, "
+				f"until the next reload or restart)"
+			)
+
 	async def handle_ring_device(call: ServiceCall) -> None:
 		"""Handle ring_device service call - make the device sound."""
 		_require_client()
@@ -893,6 +927,13 @@ async def async_setup_services(hass: HomeAssistant, coordinator: FamilyLinkDataU
 		schema=SCHEMA_RING_DEVICE,
 	)
 
+	hass.services.async_register(
+		DOMAIN,
+		SERVICE_SET_UPDATE_INTERVAL,
+		handle_set_update_interval,
+		schema=SCHEMA_SET_UPDATE_INTERVAL,
+	)
+
 	_LOGGER.debug("Family Link services registered")
 
 
@@ -928,6 +969,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 			hass.services.async_remove(DOMAIN, SERVICE_SET_DAILY_LIMIT)
 			hass.services.async_remove(DOMAIN, SERVICE_SET_BEDTIME)
 			hass.services.async_remove(DOMAIN, SERVICE_REFRESH_LOCATION)
+			hass.services.async_remove(DOMAIN, SERVICE_RING_DEVICE)
+			hass.services.async_remove(DOMAIN, SERVICE_SET_UPDATE_INTERVAL)
 			_LOGGER.debug("Family Link services unregistered")
 
 	return unload_ok

--- a/custom_components/familylink/const.py
+++ b/custom_components/familylink/const.py
@@ -16,6 +16,8 @@ CONF_ENABLE_LOCATION_TRACKING: Final = "enable_location_tracking"
 
 # Default values
 DEFAULT_UPDATE_INTERVAL: Final = 60  # seconds
+MIN_UPDATE_INTERVAL: Final = 30  # seconds
+MAX_UPDATE_INTERVAL: Final = 3600  # seconds
 DEFAULT_TIMEOUT: Final = 30  # seconds
 DEFAULT_COOKIE_FILE: Final = "familylink_cookies.json"
 
@@ -82,3 +84,6 @@ SERVICE_REFRESH_LOCATION: Final = "refresh_location"
 
 # Device remote actions
 SERVICE_RING_DEVICE: Final = "ring_device"
+
+# Polling
+SERVICE_SET_UPDATE_INTERVAL: Final = "set_update_interval"

--- a/custom_components/familylink/services.yaml
+++ b/custom_components/familylink/services.yaml
@@ -446,3 +446,19 @@ ring_device:
       selector:
         text:
 
+
+set_update_interval:
+  name: Set Update Interval
+  description: Change how often the integration polls Google, until the next reload or restart (the value from the integration options applies again afterwards). Lets an automation poll less often at night and more often during the day.
+  fields:
+    seconds:
+      name: Interval (seconds)
+      description: Polling interval in seconds, between 30 and 3600
+      required: true
+      example: 600
+      selector:
+        number:
+          min: 30
+          max: 3600
+          unit_of_measurement: seconds
+          mode: box


### PR DESCRIPTION
Refs #156. Targeted at **1.2.16**: do not merge before the stable 1.2.15 is cut from `main`.

## What

- `familylink.set_update_interval` with one required field, `seconds` (30 to 3600, same bounds as the options). Sets `update_interval` on every coordinator of the integration; takes effect at the next scheduled poll. Not persisted: after a reload or restart the value from the options applies again, so an automation can lengthen the interval at bedtime and shorten it in the morning without changing the configured value behind the user's back.
- `ring_device` is now unregistered in `async_unload_entry` (it was the only action left behind).
- `services.yaml`, `SERVICES.md`, README table and changelog updated.

## Verification

Compile only so far; to be exercised on a live instance before 1.2.16 (call the action, check the "polling every Ns" log line and the spacing of the next fetches).